### PR TITLE
Change abbreviation BSS to BASocSc

### DIFF
--- a/lib/dfe/reference_data/degrees.rb
+++ b/lib/dfe/reference_data/degrees.rb
@@ -297,8 +297,8 @@ module DfE
             hesa_itt_code: '88' },
           '276a5652-c197-e711-80d8-005056ac45bb' =>
           { name: 'Bachelor of Social Science',
-            abbreviation: 'BSS',
-            synonyms: [],
+            abbreviation: 'BaSocSc',
+            synonyms: ['BSS'],
             qualification: 'b580a760-da23-4d38-b803-62ae11de6a65',
             dqt_id: '276a5652-c197-e711-80d8-005056ac45bb',
             hesa_itt_code: '89' },


### PR DESCRIPTION
Reviewing usage of our new degree flow, someone had typed in `BASocSc`, an abbreviation for Bachelor of Social Science.

We already have a "Bachelor of Social Science" degree type, but the abbreviation was BSS. According to Wikipedia, [both are used](https://en.wikipedia.org/wiki/Bachelor_of_Social_Science) worldwide. 

I did some quick Googling, and found that the University of Manchester currently award a BASocSc: [BSocSc Sociology](https://www.manchester.ac.uk/study/undergraduate/courses/2022/00678/bsocsc-sociology/). All other undergraduate social sciences degrees seem to award BA or BSc. I could find no course offering a degree with a BSS abbreviation. No candidate has previously entered BSS as their degree type either.

I've added BSS as a synonym just in case.