### PR TITLE
Add suggestion synonym: Henley Business School

### DIFF
--- a/lib/dfe/reference_data/degrees.rb
+++ b/lib/dfe/reference_data/degrees.rb
@@ -1662,7 +1662,7 @@ module DfE
             ukprn: '10007774' },
           '3471f34a-2887-e711-80d8-005056ac45bb' =>
           { name: 'University of Reading',
-            suggestion_synonyms: [],
+            suggestion_synonyms: ['Henley Business School'],
             match_synonyms: ['The University of Reading'],
             hesa_itt_code: '157',
             dttp_id: '3471f34a-2887-e711-80d8-005056ac45bb',


### PR DESCRIPTION
Henley Business School is now part of the University of Reading, but used to be independent and has its own identity:

* https://www.henley.ac.uk
* https://en.wikipedia.org/wiki/Henley_Business_School