### PR TITLE
Add Classics as synonym for Classical Studies

### DIFF
--- a/lib/dfe/reference_data/degrees.rb
+++ b/lib/dfe/reference_data/degrees.rb
@@ -4152,7 +4152,7 @@ module DfE
             hesa_itt_code: '101129' },
           'c38070f0-5dce-e911-a985-000d3ab79618' =>
           { name: 'Classical studies',
-            synonyms: [],
+            synonyms: ['Classics'],
             dttp_id: 'c38070f0-5dce-e911-a985-000d3ab79618',
             hesa_itt_code: '100300' },
           '258570f0-5dce-e911-a985-000d3ab79618' =>


### PR DESCRIPTION
These seem to be synonyms, with some universities using 'Classics' and others using 'Classical Studies'.

The UCAS subject guide uses both terms: https://www.ucas.com/explore/subjects/classical-studies