### PR TITLE
Add Computing as a stand-alone subject

### DIFF
--- a/lib/dfe/reference_data/degrees.rb
+++ b/lib/dfe/reference_data/degrees.rb
@@ -4389,7 +4389,8 @@ module DfE
           { name: 'Computing',
             synonyms: [],
             dttp_id: nil,
-            hesa_itt_code: '100367' },
+            hesa_itt_code: '100367',
+            comment: 'This is a common degree subject, and has been mapped to HESA code 100367 (Computing and information technology) which is the closest match.' },
           '318170f0-5dce-e911-a985-000d3ab79618' =>
           { name: 'Computing and information technology',
             synonyms: [],

--- a/lib/dfe/reference_data/degrees.rb
+++ b/lib/dfe/reference_data/degrees.rb
@@ -4385,6 +4385,11 @@ module DfE
             synonyms: [],
             dttp_id: 'a38470f0-5dce-e911-a985-000d3ab79618',
             hesa_itt_code: '100968' },
+          'a042524a-b918-457c-bfaf-2e2432785d6d' =>
+          { name: 'Computing',
+            synonyms: [],
+            dttp_id: nil,
+            hesa_itt_code: '100367' },
           '318170f0-5dce-e911-a985-000d3ab79618' =>
           { name: 'Computing and information technology',
             synonyms: [],


### PR DESCRIPTION
38 candidates have entered 'Computing' as their degree subject.

Whilst "Computing and information technology" is in the list, as does "Information technology", "Creative computing", "Applied computing", "Parallel computing", "Neural computing", "High performance computing", "Business computing", "Computer science", and so on... - "Computing" is not listed as a standalone subject.

Examples of undergraduate courses which use 'Computing' as degree title:

* https://www.gre.ac.uk/undergraduate-courses/ach/computing-bsc-hons
* https://www.imperial.ac.uk/study/ug/courses/computing-department/computing-beng/
* https://www.port.ac.uk/study/courses/bsc-hons-computing

The HESA code 100367 (Computing and information technology) is reused as this is likely the closest match.