### PR TITLE
Split out compound subjects

### DIFF
--- a/docs/lists_degrees.md
+++ b/docs/lists_degrees.md
@@ -102,7 +102,7 @@ Quality: Manually updated on an ad-hoc basis. Please submit a pull request if in
 | `group` | enumerated symbol | The kind of degree this grade applies to. `main_postgrad`, `other` or `main_undergrad` |
 | `hesa_code` | string | The HESA code for this degree grade. |
 
-### `DfE::ReferenceData::Degrees::SUBJECTS`
+### `DfE::ReferenceData::Degrees::SINGLE_SUBJECTS`
 
 ```ruby
 require 'dfe/reference_data/degrees'
@@ -125,6 +125,54 @@ Quality: Manually updated on an ad-hoc basis. Please submit a pull request if in
 | `synonyms` | string array | A list of common alternative names |
 | `dttp_id` | uuid | The ID used for this subject in DTTP |
 | `hesa_itt_code` | string | The ID used for this subject in HESA |
+
+### `DfE::ReferenceData::Degrees::COMMON_COMPOUND_SUBJECTS`
+
+```ruby
+require 'dfe/reference_data/degrees'
+```
+
+Common combinations of degree subjects (Eg, subjects of the form "X with Y" or "X and Y")
+
+Owner: Apply team.
+
+Users: Apply team.
+
+Source: https://github.com/DFE-Digital/apply-for-teacher-training-prototype/blob/main/app/data/degree-subjects.js
+
+Quality: Manually updated on an ad-hoc basis. Please submit a pull request if inaccuracies or omissions are found.
+
+| Field | Type | Purpose |
+|---|---|---|
+| `id` | UUID | A unique identifier. The same as `dttp_id` if that field is non-`nil`, otherwise a new UUID was minted at import time. |
+| `name` | string | The long name of the subject, eg "accountancy" |
+| `synonyms` | string array | A list of common alternative names |
+| `components` | UUID array | The `SINGLE_SUBJECTS` IDs of the compound parts, in order |
+
+### `DfE::ReferenceData::Degrees::SUBJECTS`
+
+```ruby
+require 'dfe/reference_data/degrees'
+```
+
+The union of `SINGLE_SUBJECTS` and `COMMON_COMPOUND_SUBJECTS`.
+
+Owner: Apply team.
+
+Users: Apply team.
+
+Source: Automatically derived from joining the `SINGLE_SUBJECTS` and `COMMON_COMPOUND_SUBJECTS` lists.
+
+Quality: Automatically derived from the source data, so only as correct as they are.
+
+| Field | Type | Purpose |
+|---|---|---|
+| `id` | UUID | A unique identifier. The same as `dttp_id` if that field is non-`nil`, otherwise a new UUID was minted at import time. |
+| `name` | string | The long name of the subject, eg "accountancy" |
+| `synonyms` | string array | A list of common alternative names |
+| `dttp_id` | optional uuid | The ID used for this subject in DTTP (for single subjects) |
+| `hesa_itt_code` | optional string | The ID used for this subject in HESA (for single subjects) |
+| `components` | optional UUID array | The `SINGLE_SUBJECTS` IDs of the compound parts, in order (for compound subjects) |
 
 ### `DfE::ReferenceData::Degrees::INSTITUTIONS`
 

--- a/lib/dfe/reference_data/degrees/subjects.rb
+++ b/lib/dfe/reference_data/degrees/subjects.rb
@@ -1,7 +1,7 @@
 module DfE
   module ReferenceData
     module Degrees
-      SUBJECTS = DfE::ReferenceData::HardcodedReferenceList.new(
+      SINGLE_SUBJECTS = DfE::ReferenceData::HardcodedReferenceList.new(
         { '917f70f0-5dce-e911-a985-000d3ab79618' =>
           { name: 'Accountancy',
             synonyms: [],
@@ -1813,12 +1813,6 @@ module DfE
             synonyms: [],
             dttp_id: 'e18070f0-5dce-e911-a985-000d3ab79618',
             hesa_itt_code: '100320' },
-          'dd967b4a-4d22-48a3-a2f8-d5719cee0519' =>
-          { name: 'English language and literature',
-            synonyms: [],
-            dttp_id: nil,
-            hesa_itt_code: nil,
-            comment: 'This is a common combined degree subject. Ideally it would map to 2 HESA codes, 100318 and 100319.' },
           '0b8670f0-5dce-e911-a985-000d3ab79618' =>
           { name: 'Enterprise and entrepreneurship',
             synonyms: [],
@@ -5475,6 +5469,20 @@ module DfE
             dttp_id: '1f8170f0-5dce-e911-a985-000d3ab79618',
             hesa_itt_code: '100356' } }
       )
+
+      COMMON_COMPOUND_SUBJECTS = DfE::ReferenceData::HardcodedReferenceList.new(
+        {
+          'dd967b4a-4d22-48a3-a2f8-d5719cee0519' =>
+          {
+            name: 'English language and literature',
+            synonyms: [],
+            components: ['dd8070f0-5dce-e911-a985-000d3ab79618', # English language
+                         'df8070f0-5dce-e911-a985-000d3ab79618'] # English literature
+          }
+        }
+      )
+
+      SUBJECTS = DfE::ReferenceData::JoinedReferenceList.new([SINGLE_SUBJECTS, COMMON_COMPOUND_SUBJECTS])
     end
   end
 end


### PR DESCRIPTION
To tidy up the structure of the subject list, we can split out "single subjects" from "compound subjects", and make the latter reference an ordered array of the single subjects that comprise them. This makes it easier for downstream code to pick out "All subjects of the form English (and anything)", and things like that.