### PR TITLE
fix-synonym-for-pe

### DIFF
--- a/lib/dfe/reference_data/degrees/subjects.rb
+++ b/lib/dfe/reference_data/degrees/subjects.rb
@@ -4763,7 +4763,7 @@ module DfE
             hecos_code: '101050' },
           'ba1ffe89-73fb-4de8-a48d-12e644ee5687' =>
            { name: 'Physical education',
-             synonyms: ['PE'],
+             suggestion_synonyms: ['PE'],
              dttp_id: nil,
              hecos_code: '100433',
              comment: 'This is matched to the 100433 code for "Sport and exercise sciences" following HECOS guidance. A future HECOS update may add PE as a separate code.' },


### PR DESCRIPTION
We mistakenly added a "PE" synonym for "Physical education" instead of a `match_synonym` or `suggestion_synonym`.