### PR TITLE
Add new master level degree types

### DIFF
--- a/docs/lists_degrees.md
+++ b/docs/lists_degrees.md
@@ -30,6 +30,7 @@ Quality: Manually updated on an ad-hoc basis. Please submit a pull request if in
 | `qualification` | string | The ID of the qualification level of this degree (see [`DfE::ReferenceData::Qualifications::QUALIFICATIONS`](lists_qualifications.md)) |
 | `dqt_id` | uuid | The ID used for this qualification in DQT |
 | `hesa_itt_code` | string | The ID used for this qualification in HESA |
+| `comment` | string | Any extra commend or description for the field |
 
 ### `DfE::ReferenceData::Degrees::GENERIC_TYPES`
 

--- a/lib/dfe/reference_data/degrees/types.rb
+++ b/lib/dfe/reference_data/degrees/types.rb
@@ -507,7 +507,9 @@ module DfE
             match_synonyms: ['masters in science'],
             qualification: '4b7f4349-a981-4441-8f4d-ad2d0e57c8e9',
             dqt_id: nil,
-            hesa_itt_code: nil },
+            hesa_itt_code: nil,
+            comment: 'This is a qualificatoin distinct from Master of Science. MSci are typically four year courses
+            including three years of undergraduate study.' },
           '456a5652-c197-e711-80d8-005056ac45bb' =>
           { priority: 1,
             name: 'Master of Science',

--- a/lib/dfe/reference_data/degrees/types.rb
+++ b/lib/dfe/reference_data/degrees/types.rb
@@ -467,6 +467,17 @@ module DfE
             qualification: '4b7f4349-a981-4441-8f4d-ad2d0e57c8e9',
             dqt_id: '3f6a5652-c197-e711-80d8-005056ac45bb',
             hesa_itt_code: '202' },
+          'f3eaa983-d543-4d4b-a239-f46d7cc94825' =>
+          { name: 'Master of Mathematics',
+            abbreviation: 'MMath',
+            suggestion_synonyms: [],
+            match_synonyms: [
+              'masters of mathematics',
+              'masters of maths'
+            ],
+            qualification: '4b7f4349-a981-4441-8f4d-ad2d0e57c8e9',
+            dqt_id: nil,
+            hesa_itt_code: nil },
           '416a5652-c197-e711-80d8-005056ac45bb' =>
           { name: 'Master of Music',
             abbreviation: 'MMus',
@@ -481,6 +492,22 @@ module DfE
             qualification: '4b7f4349-a981-4441-8f4d-ad2d0e57c8e9',
             dqt_id: '436a5652-c197-e711-80d8-005056ac45bb',
             hesa_itt_code: '204' },
+          'cfae21bd-2b03-4048-bfdd-5f768c5b85e9' =>
+          { name: 'Master of Research',
+            abbreviation: 'MRes',
+            suggestion_synonyms: [],
+            match_synonyms: ['masters of research'],
+            qualification: '4b7f4349-a981-4441-8f4d-ad2d0e57c8e9',
+            dqt_id: nil,
+            hesa_itt_code: nil },
+          'b6d2c5aa-cf99-4831-9bfe-6279349d8ea9' =>
+          { name: 'Master in Science',
+            abbreviation: 'MSci',
+            suggestion_synonyms: [],
+            match_synonyms: ['masters in science'],
+            qualification: '4b7f4349-a981-4441-8f4d-ad2d0e57c8e9',
+            dqt_id: nil,
+            hesa_itt_code: nil },
           '456a5652-c197-e711-80d8-005056ac45bb' =>
           { priority: 1,
             name: 'Master of Science',


### PR DESCRIPTION
Adds three new master level qualifications which we saw somewhat regularly in the Apply free text data.

Note `Master in science (MSci)` is a distinct and different type from `Master of science (MSc)`.