### PR TITLE
Add new HESA codes from C22053

### DIFF
--- a/lib/dfe/reference_data/degrees/institutions.rb
+++ b/lib/dfe/reference_data/degrees/institutions.rb
@@ -2435,7 +2435,7 @@ module DfE
               'Newcastle College Group',
               'Newcastle College university centre'
             ],
-            hesa_itt_code: nil,
+            hesa_itt_code: '1078',
             dttp_id: '20e5a08c-ee97-e711-80d8-005056ac45bb',
             ukprn: '10004599' },
           '6a228041-7042-e811-80ff-3863bb3640b8' =>
@@ -2460,7 +2460,7 @@ module DfE
              'Grimsby Institute of Further and Higher Education',
              'Grimsby Institute of Further & Higher Education'],
             match_synonyms: [],
-            hesa_itt_code: nil,
+            hesa_itt_code: '1119',
             dttp_id: nil,
             comment:
             'Given degree awarding powers in 2021. Partnership for several colleges.',
@@ -2469,7 +2469,7 @@ module DfE
           { name: 'WCG (Warwickshire College Group)',
             suggestion_synonyms: [],
             match_synonyms: ['Warwickshire College', 'Warwickshire College Group'],
-            hesa_itt_code: nil,
+            hesa_itt_code: '1015',
             dttp_id: nil,
             ukprn: '10007859',
             comment: 'Given degree awarding powers in 2021' },


### PR DESCRIPTION
For 22/23 HESA has made a number of changes to the degree institution field.

Three of the entries we already had have now been added to [HESA in C22053](https://www.hesa.ac.uk/collection/c22053/e/degest). This updates to use the new HESA codes.

Note this does *not* add any other new items added in HESA.