### PR TITLE
Fix schema validation (so we can import to bigquery again)

### DIFF
--- a/lib/dfe/reference_data/degrees/types.rb
+++ b/lib/dfe/reference_data/degrees/types.rb
@@ -23,6 +23,13 @@ module DfE
         }
       )
 
+      TYPES_INCLUDING_GENERICS_SCHEMA = TYPES_SCHEMA.merge(
+        {
+          qualification: { kind: :optional, schema: :string },
+          generic: { kind: :optional, schema: :boolean }
+        }
+      )
+
       TYPES = DfE::ReferenceData::HardcodedReferenceList.new(
         { 'be08f598-0860-4de0-b95a-3c448a16cc99' =>
           { name: 'Foundation degree',
@@ -801,7 +808,6 @@ module DfE
             abbreviation: nil,
             suggestion_synonyms: [],
             match_synonyms: [],
-            qualification: nil,
             dttp_id: nil,
             hesa_itt_code: '400',
             generic: true },
@@ -832,7 +838,6 @@ module DfE
               'Level 8 diploma'
             ],
             match_synonyms: [],
-            qualification: nil,
             dttp_id: nil,
             hesa_itt_code: '401',
             generic: true },
@@ -854,7 +859,6 @@ module DfE
               'Ordinary degree'
             ],
             match_synonyms: [],
-            qualification: nil,
             dttp_id: nil,
             hesa_itt_code: '402',
             generic: true }
@@ -864,7 +868,7 @@ module DfE
 
       TYPES_INCLUDING_GENERICS = DfE::ReferenceData::JoinedReferenceList.new(
         [TYPES, GENERIC_TYPES],
-        GENERIC_TYPES_SCHEMA
+        TYPES_INCLUDING_GENERICS_SCHEMA
       )
     end
   end

--- a/lib/dfe/reference_data/record.rb
+++ b/lib/dfe/reference_data/record.rb
@@ -23,6 +23,14 @@ module DfE
                   other.data
                 end
       end
+
+      def to_s
+        if data.key?(:name)
+          "#<DfE::ReferenceData::Record id=#{id} name=#{name}>"
+        else
+          "#<DfE::ReferenceData::Record id=#{id}>"
+        end
+      end
     end
     # rubocop:enable Style/OpenStructUse
   end

--- a/lib/dfe/reference_data/record.rb
+++ b/lib/dfe/reference_data/record.rb
@@ -24,7 +24,7 @@ module DfE
                 end
       end
 
-      def to_s
+      def inspect
         if data.key?(:name)
           "#<DfE::ReferenceData::Record id=#{id} name=#{name}>"
         else

--- a/spec/lib/dfe/reference_data/schema_validation_spec.rb
+++ b/spec/lib/dfe/reference_data/schema_validation_spec.rb
@@ -1,0 +1,114 @@
+RSpec.describe Validator do
+  let(:test_data) do
+    DfE::ReferenceData::HardcodedReferenceList.new(
+      # Data
+      {
+        'good full record' => {
+          single_string: 'hello',
+          single_symbol: :world,
+          single_boolean: true,
+          single_integer: 123,
+          single_real: 123.456,
+
+          optional_string: 'optional hello',
+          optional_symbol: :optional_world,
+          optional_boolean: false,
+          optional_integer: 456,
+          optional_real: 456.789,
+
+          array_string: ['array', 'of', 'strings'],
+          array_symbol: %i[array of symbols],
+          array_boolean: [true, false],
+          array_integer: [1, 2, 3],
+          array_real: [1.0, 2.0, 3.0]
+        },
+        'good sparse record' => {
+          single_string: 'goodbye',
+          single_symbol: :everybody,
+          single_boolean: false,
+          single_integer: -1,
+          single_real: -123.456
+        },
+        'missing fields' => {
+        },
+        'extra fields' => {
+          single_string: 'goodbye',
+          single_symbol: :everybody,
+          single_boolean: false,
+          single_integer: -1,
+          single_real: -123.456,
+
+          undeclared_field: :rubbish
+        },
+        'mistyped fields 1' => {
+          single_string: :symbol,
+          single_symbol: 'string',
+          single_boolean: 'not a boolean',
+          single_integer: 'not an integer',
+          single_real: 'not a real',
+
+          optional_string: :symbol,
+          optional_symbol: 'string',
+          optional_boolean: 'not a boolean',
+          optional_integer: 'not an integer',
+          optional_real: 'not a real',
+
+          array_string: [1],
+          array_symbol: [1],
+          array_boolean: [1],
+          array_integer: [1, 2, 'not an integer'],
+          array_real: [1.0, 2.0, 3.0, 'not a real']
+        },
+        'mistyped fields 2' => {
+          single_string: 'hello',
+          single_symbol: :world,
+          single_boolean: true,
+          single_integer: 123,
+          single_real: 123.456,
+
+          optional_string: 'optional hello',
+          optional_symbol: :optional_world,
+          optional_boolean: false,
+          optional_integer: 456,
+          optional_real: 456.789,
+
+          array_string: 'not an array',
+          array_symbol: :not_an_array,
+          array_boolean: 'not an array',
+          array_integer: 'not an array',
+          array_real: 'not an array'
+        }
+      },
+      # Schema
+      {
+        id: :string,
+        single_string: :string,
+        single_symbol: :symbol,
+        single_boolean: :boolean,
+        single_integer: :integer,
+        single_real: :real,
+        optional_string: { kind: :optional, schema: :string },
+        optional_symbol: { kind: :optional, schema: :symbol },
+        optional_boolean: { kind: :optional, schema: :boolean },
+        optional_integer: { kind: :optional, schema: :integer },
+        optional_real: { kind: :optional, schema: :real },
+        array_string: { kind: :array, element_schema: :string },
+        array_symbol: { kind: :array, element_schema: :symbol },
+        array_boolean: { kind: :array, element_schema: :boolean },
+        array_integer: { kind: :array, element_schema: :integer },
+        array_real: { kind: :array, element_schema: :real }
+      }
+    )
+  end
+
+  it 'validates records correctly' do
+    errors = described_class.validate_records(test_data.all, test_data.schema)
+
+    expect(errors.keys.map(&:id)).to contain_exactly(
+      'missing fields',
+      'extra fields',
+      'mistyped fields 1',
+      'mistyped fields 2'
+    )
+  end
+end

--- a/spec/support/schema_validation.rb
+++ b/spec/support/schema_validation.rb
@@ -90,13 +90,13 @@ class Validator
     end
   end
 
-  def self.is_optional_field?(field_schema)
+  def self.required_field?(field_schema)
     case field_schema
     when Symbol
-      false
+      true
     when Hash
       # A missing array is as good as an empty array
-      ((field_schema[:kind] == :optional) or (field_schema[:kind] == :array))
+      ((field_schema[:kind] != :optional) and (field_schema[:kind] != :array))
     else
       raise InvalidSchemaError, "Incomprehensible schema '#{field_schema}'"
     end
@@ -119,7 +119,7 @@ class Validator
     end
     # 2) All non-optional fields in schema are found in record
     schema.each_pair do |key, field_schema|
-      raise MissingFieldError.new(record, key) if !is_optional_field?(field_schema) && !record_data.key?(key)
+      raise MissingFieldError.new(record, key) if required_field?(field_schema) && !record_data.key?(key)
     end
   end
 

--- a/spec/support/schema_validation.rb
+++ b/spec/support/schema_validation.rb
@@ -90,6 +90,18 @@ class Validator
     end
   end
 
+  def self.is_optional_field?(field_schema)
+    case field_schema
+    when Symbol
+      false
+    when Hash
+      # A missing array is as good as an empty array
+      ((field_schema[:kind] == :optional) or (field_schema[:kind] == :array))
+    else
+      raise InvalidSchemaError, "Incomprehensible schema '#{field_schema}'"
+    end
+  end
+
   ##
   # Validate a record against a schema
   # Raises errors if validation fails.
@@ -106,7 +118,9 @@ class Validator
       validate_field!(record, key, fs, value)
     end
     # 2) All non-optional fields in schema are found in record
-    # ABS FIXME
+    schema.each_pair do |key, field_schema|
+      raise MissingFieldError.new(record, key) if !is_optional_field?(field_schema) && !record_data.key?(key)
+    end
   end
 
   ##
@@ -119,7 +133,6 @@ class Validator
     rescue StandardError => e
       errors[record] = e
     end
-
     errors
   end
 end
@@ -132,7 +145,7 @@ RSpec::Matchers.define :have_all_records_matching_the_schema do
 
   failure_message do |actual|
     errors = Validator.validate_records(actual.all, actual.schema)
-    return "had the following errors: #{errors}"
+    return "had the following errors: #{errors.values}"
   end
 end
 


### PR DESCRIPTION
Fixes https://trello.com/c/V23Zyuc7/904-investigate-reference-data-deploy-to-bigquery-failure

The cause was that half of the schema validator wasn't implemented (how did nobody spot that?!?), so hadn't picked up a mistake with a schema - but BigQuery *did* pick up the problem when it tried to import the data we have into a table created with that schema.

This PR:

- Fixes the schema validator
- Adds tests for the schema validator
- Fixes the wrong schema