### PR TITLE
Code pattern schemas

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -15,7 +15,11 @@ The schema format is a hash mapping field name symbols to the schema for that fi
 
 #### Simple field schemas
 
-If a field is compulsory and isn't an array, then its field schema is just a symbol.
+If a field is compulsory and isn't an array, then its field schema is said to be "simple".
+
+##### Bare types
+
+Bare types are just represented as a symbol.
 
 | Schema symbol | Meaning              |
 |---------------|----------------------|
@@ -24,6 +28,21 @@ If a field is compulsory and isn't an array, then its field schema is just a sym
 | `:boolean`      | `true` or `false`    |
 | `:integer`      | An integer, from -4611686018427387904 to  4611686018427387903 inclusive |
 | `:real`         | A real number, from -1.7976931348623157e+308 to 1.7976931348623157e+308, stored approximately |
+
+##### Code fields
+
+Rather than using `:string` for IDs or codes, it's best to use a code schema
+that specifies a [regular expression
+pattern](https://ruby-doc.org/core-3.1.2/Regexp.html) the value must follow,
+like so:
+
+`{kind: :code, pattern: /[REGEXP]/}'
+
+The regexp should usually be anchored with `^` and `$` to require it to match the entire string.
+
+For instance:
+
+`{kind: :code, pattern: /^[0-9]{4}$/}`
 
 #### Optional fields
 

--- a/lib/dfe/reference_data/bigquery/importer.rb
+++ b/lib/dfe/reference_data/bigquery/importer.rb
@@ -93,6 +93,13 @@ module DfE
 
         def bigquery_schema_create_field(schema, name, kind, mode)
           case kind
+          when Hash
+            case kind[:kind]
+            when :code
+              schema.string name, mode: mode
+            else
+              raise "Schema error: #{kind}"
+            end
           # rubocop:disable Lint/DuplicateBranch
           when :string
             schema.string name, mode: mode
@@ -120,6 +127,8 @@ module DfE
               bigquery_schema_create_field(schema, field_name, field_schema[:element_schema], :repeated)
             when :optional
               bigquery_schema_create_field(schema, field_name, field_schema[:schema], :nullable)
+            when :code
+              bigquery_schema_create_field(schema, field_name, :string, :required)
             else
               raise "Complex schema kind error: #{field_schema[:kind]}"
             end

--- a/lib/dfe/reference_data/bigquery/importer.rb
+++ b/lib/dfe/reference_data/bigquery/importer.rb
@@ -91,16 +91,20 @@ module DfE
           end
         end
 
-        def bigquery_schema_create_field(schema, name, kind, mode)
-          case kind
+        def kind(field_schema)
+          case field_schema
           when Hash
-            case kind[:kind]
-            when :code
-              schema.string name, mode: mode
-            else
-              raise "Schema error: #{kind}"
-            end
+            field_schema[:kind]
+          else
+            field_schema
+          end
+        end
+
+        def bigquery_schema_create_field(schema, name, field_schema, mode)
+          case kind(field_schema)
           # rubocop:disable Lint/DuplicateBranch
+          when :code
+            schema.string name, mode: mode
           when :string
             schema.string name, mode: mode
           when :symbol

--- a/lib/dfe/reference_data/degrees/grades.rb
+++ b/lib/dfe/reference_data/degrees/grades.rb
@@ -4,7 +4,7 @@ module DfE
       GRADES_SCHEMA = {
         id: :string,
         name: :string,
-        hesa_code: :string,
+        hesa_code: { kind: :code, pattern: /^[0-9]+$/ },
         suggestion_synonyms: { kind: :array, element_schema: :string },
         match_synonyms: { kind: :array, element_schema: :string },
         group: :symbol

--- a/lib/dfe/reference_data/degrees/institutions.rb
+++ b/lib/dfe/reference_data/degrees/institutions.rb
@@ -8,7 +8,7 @@ module DfE
         match_synonyms: { kind: :array, element_schema: :string },
         hesa_itt_code: { kind: :optional, schema: { kind: :code, pattern: /^[0-9]+$/ } },
         dttp_id: { kind: :optional, schema: { kind: :code, pattern: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ } },
-        ukprn: { kind: :optional, schema:  { kind: :code, pattern: /^[0-9]+$/ } },
+        ukprn: { kind: :optional, schema: { kind: :code, pattern: /^[0-9]+$/ } },
         comment: { kind: :optional, schema: :string },
         closed: { kind: :optional, schema: :string },
         has_never_awarded_degrees: { kind: :optional, schema: :boolean }

--- a/lib/dfe/reference_data/degrees/institutions.rb
+++ b/lib/dfe/reference_data/degrees/institutions.rb
@@ -6,9 +6,9 @@ module DfE
         name: :string,
         suggestion_synonyms: { kind: :array, element_schema: :string },
         match_synonyms: { kind: :array, element_schema: :string },
-        hesa_itt_code: { kind: :optional, schema: :string },
-        dttp_id: { kind: :optional, schema: :string },
-        ukprn: { kind: :optional, schema: :string },
+        hesa_itt_code: { kind: :optional, schema: { kind: :code, pattern: /^[0-9]+$/ } },
+        dttp_id: { kind: :optional, schema: { kind: :code, pattern: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ } },
+        ukprn: { kind: :optional, schema:  { kind: :code, pattern: /^[0-9]+$/ } },
         comment: { kind: :optional, schema: :string },
         closed: { kind: :optional, schema: :string },
         has_never_awarded_degrees: { kind: :optional, schema: :boolean }

--- a/lib/dfe/reference_data/degrees/subjects.rb
+++ b/lib/dfe/reference_data/degrees/subjects.rb
@@ -11,8 +11,8 @@ module DfE
 
       SINGLE_SUBJECTS_SCHEMA = CORE_SUBJECTS_SCHEMA.merge(
         {
-          dttp_id: { kind: :optional, schema: :string },
-          hecos_code: { kind: :optional, schema: :string }
+          dttp_id: { kind: :optional, schema: { kind: :code, pattern: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ } },
+          hecos_code: { kind: :optional, schema: { kind: :code, pattern: /^[0-9]+$/ } }
         }
       )
 
@@ -22,13 +22,7 @@ module DfE
         }
       )
 
-      SUBJECTS_SCHEMA = CORE_SUBJECTS_SCHEMA.merge(
-        {
-          subject_ids: { kind: :array, element_schema: :string },
-          dttp_id: { kind: :optional, schema: :string },
-          hecos_code: { kind: :optional, schema: :string }
-        }
-      )
+      SUBJECTS_SCHEMA = SINGLE_SUBJECTS_SCHEMA.merge(COMBINED_SUBJECTS_SCHEMA)
 
       SINGLE_SUBJECTS = DfE::ReferenceData::HardcodedReferenceList.new(
         { '917f70f0-5dce-e911-a985-000d3ab79618' =>

--- a/lib/dfe/reference_data/degrees/types.rb
+++ b/lib/dfe/reference_data/degrees/types.rb
@@ -9,8 +9,8 @@ module DfE
         priority: { kind: :optional, schema: :integer },
         abbreviation: { kind: :optional, schema: :string },
         qualification: :string,
-        dttp_id: { kind: :optional, schema: :string },
-        hesa_itt_code: { kind: :optional, schema: :string },
+        dttp_id: { kind: :optional, schema: { kind: :code, pattern: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/ } },
+        hesa_itt_code: { kind: :optional, schema: { kind: :code, pattern: /^[0-9]+$/ } },
         deprecated: { kind: :optional, schema: :boolean },
         comment: { kind: :optional, schema: :string },
         hint: { kind: :optional, schema: :string }

--- a/lib/dfe/reference_data/qualifications.rb
+++ b/lib/dfe/reference_data/qualifications.rb
@@ -4,7 +4,7 @@ module DfE
       QUALIFICATIONS_SCHEMA = {
         id: :string,
         name: :string,
-        level: :string,
+        level: { kind: :code, pattern: /^entry|[1-8]$/},
         suggestion_synonyms: { kind: :array, element_schema: :string },
         match_synonyms: { kind: :array, element_schema: :string },
         degree: { kind: :optional, schema: :symbol },

--- a/lib/dfe/reference_data/qualifications.rb
+++ b/lib/dfe/reference_data/qualifications.rb
@@ -4,7 +4,7 @@ module DfE
       QUALIFICATIONS_SCHEMA = {
         id: :string,
         name: :string,
-        level: { kind: :code, pattern: /^entry|[1-8]$/},
+        level: { kind: :code, pattern: /^entry|[1-8]$/ },
         suggestion_synonyms: { kind: :array, element_schema: :string },
         match_synonyms: { kind: :array, element_schema: :string },
         degree: { kind: :optional, schema: :symbol },

--- a/spec/lib/dfe/reference_data/schema_validation_spec.rb
+++ b/spec/lib/dfe/reference_data/schema_validation_spec.rb
@@ -9,27 +9,36 @@ RSpec.describe Validator do
           single_boolean: true,
           single_integer: 123,
           single_real: 123.456,
+          single_code: '0000',
 
           optional_string: 'optional hello',
           optional_symbol: :optional_world,
           optional_boolean: false,
           optional_integer: 456,
           optional_real: 456.789,
+          optional_code: '9999',
 
           array_string: ['array', 'of', 'strings'],
           array_symbol: %i[array of symbols],
           array_boolean: [true, false],
           array_integer: [1, 2, 3],
-          array_real: [1.0, 2.0, 3.0]
+          array_real: [1.0, 2.0, 3.0],
+          array_code: ['0000', '9999']
         },
         'good sparse record' => {
           single_string: 'goodbye',
           single_symbol: :everybody,
           single_boolean: false,
           single_integer: -1,
-          single_real: -123.456
+          single_real: -123.456,
+          single_code: '1111'
         },
         'missing fields' => {
+          single_symbol: :everybody,
+          single_boolean: false,
+          single_integer: -1,
+          single_real: -123.456,
+          single_code: '1111'
         },
         'extra fields' => {
           single_string: 'goodbye',
@@ -40,43 +49,73 @@ RSpec.describe Validator do
 
           undeclared_field: :rubbish
         },
-        'mistyped fields 1' => {
-          single_string: :symbol,
-          single_symbol: 'string',
-          single_boolean: 'not a boolean',
-          single_integer: 'not an integer',
-          single_real: 'not a real',
-
-          optional_string: :symbol,
-          optional_symbol: 'string',
-          optional_boolean: 'not a boolean',
-          optional_integer: 'not an integer',
-          optional_real: 'not a real',
-
-          array_string: [1],
-          array_symbol: [1],
-          array_boolean: [1],
-          array_integer: [1, 2, 'not an integer'],
-          array_real: [1.0, 2.0, 3.0, 'not a real']
+        'wrong string' => {
+          single_string: :not_a_string,
+          single_symbol: :everybody,
+          single_boolean: false,
+          single_integer: -1,
+          single_real: -123.456,
+          single_code: '1111'
         },
-        'mistyped fields 2' => {
+        'wrong symbol' => {
+          single_string: 'goodbye',
+          single_symbol: 'not a symbol',
+          single_boolean: false,
+          single_integer: -1,
+          single_real: -123.456,
+          single_code: '1111'
+        },
+        'wrong boolean' => {
+          single_string: 'goodbye',
+          single_symbol: :everybody,
+          single_boolean: 'not a boolean',
+          single_integer: -1,
+          single_real: -123.456,
+          single_code: '1111'
+        },
+        'wrong integer' => {
+          single_string: 'goodbye',
+          single_symbol: :everybody,
+          single_boolean: false,
+          single_integer: 'not an integer',
+          single_real: -123.456,
+          single_code: '1111'
+        },
+        'wrong real' => {
+          single_string: 'goodbye',
+          single_symbol: :everybody,
+          single_boolean: false,
+          single_integer: -1,
+          single_real: 'not a real',
+          single_code: '1111'
+        },
+        'wrong code' => {
+          single_string: 'goodbye',
+          single_symbol: :everybody,
+          single_boolean: false,
+          single_integer: -1,
+          single_real: -123.456,
+          single_code: '11110'
+        },
+        'wrong array 1' => {
           single_string: 'hello',
           single_symbol: :world,
           single_boolean: true,
           single_integer: 123,
           single_real: 123.456,
-
-          optional_string: 'optional hello',
-          optional_symbol: :optional_world,
-          optional_boolean: false,
-          optional_integer: 456,
-          optional_real: 456.789,
+          single_code: '0000',
 
           array_string: 'not an array',
-          array_symbol: :not_an_array,
-          array_boolean: 'not an array',
-          array_integer: 'not an array',
-          array_real: 'not an array'
+        },
+        'wrong array 2' => {
+          single_string: 'hello',
+          single_symbol: :world,
+          single_boolean: true,
+          single_integer: 123,
+          single_real: 123.456,
+          single_code: '0000',
+
+          array_symbol: ['not a symbol'],
         }
       },
       # Schema
@@ -87,16 +126,19 @@ RSpec.describe Validator do
         single_boolean: :boolean,
         single_integer: :integer,
         single_real: :real,
+        single_code: { kind: :code, pattern: /^[0-9]{4}$/ },
         optional_string: { kind: :optional, schema: :string },
         optional_symbol: { kind: :optional, schema: :symbol },
         optional_boolean: { kind: :optional, schema: :boolean },
         optional_integer: { kind: :optional, schema: :integer },
         optional_real: { kind: :optional, schema: :real },
+        optional_code: { kind: :optional, schema: {kind: :code, pattern: /^[0-9]{4}$/ } },
         array_string: { kind: :array, element_schema: :string },
         array_symbol: { kind: :array, element_schema: :symbol },
         array_boolean: { kind: :array, element_schema: :boolean },
         array_integer: { kind: :array, element_schema: :integer },
-        array_real: { kind: :array, element_schema: :real }
+        array_real: { kind: :array, element_schema: :real },
+        array_code: { kind: :array, element_schema: {kind: :code, pattern: /^[0-9]{4}$/ } },
       }
     )
   end
@@ -104,11 +146,28 @@ RSpec.describe Validator do
   it 'validates records correctly' do
     errors = described_class.validate_records(test_data.all, test_data.schema)
 
-    expect(errors.keys.map(&:id)).to contain_exactly(
-      'missing fields',
-      'extra fields',
-      'mistyped fields 1',
-      'mistyped fields 2'
-    )
+    expect(errors.keys).to contain_exactly(
+                             'missing fields',
+                             'extra fields',
+                             'wrong string',
+                             'wrong symbol',
+                             'wrong boolean',
+                             'wrong integer',
+                             'wrong real',
+                             'wrong code',
+                             'wrong array 1',
+                             'wrong array 2'
+                           )
+    
+    expect(errors['missing fields'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=missing fields>: Field single_string declared as required in the schema, but is missing'
+    expect(errors['extra fields'].to_s).to eq "Validation failed for #<DfE::ReferenceData::Record id=extra fields>: Field undeclared_field not declared in the schema"
+    expect(errors['wrong string'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=wrong string>: Field single_string does not match the schema string: Value not_a_string is not a string'
+    expect(errors['wrong symbol'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=wrong symbol>: Field single_symbol does not match the schema symbol: Value not a symbol is not a symbol'
+    expect(errors['wrong boolean'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=wrong boolean>: Field single_boolean does not match the schema boolean: Value not a boolean is not a boolean'
+    expect(errors['wrong integer'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=wrong integer>: Field single_integer does not match the schema integer: Value not an integer is not a integer'
+    expect(errors['wrong real'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=wrong real>: Field single_real does not match the schema real: Value not a real is not a real'
+    expect(errors['wrong code'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=wrong code>: Field single_code does not match the schema {:kind=>:code, :pattern=>/^[0-9]{4}$/}: Value 11110 does not match the field pattern'
+    expect(errors['wrong array 1'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=wrong array 1>: Field array_string does not match the schema {:kind=>:array, :element_schema=>:string}: Value not an array is not an array'
+    expect(errors['wrong array 2'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=wrong array 2>: Field array_symbol does not match the schema symbol: Value not a symbol is not a symbol'
   end
 end

--- a/spec/lib/dfe/reference_data/schema_validation_spec.rb
+++ b/spec/lib/dfe/reference_data/schema_validation_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Validator do
           single_real: 123.456,
           single_code: '0000',
 
-          array_string: 'not an array',
+          array_string: 'not an array'
         },
         'wrong array 2' => {
           single_string: 'hello',
@@ -115,7 +115,7 @@ RSpec.describe Validator do
           single_real: 123.456,
           single_code: '0000',
 
-          array_symbol: ['not a symbol'],
+          array_symbol: ['not a symbol']
         }
       },
       # Schema
@@ -132,13 +132,13 @@ RSpec.describe Validator do
         optional_boolean: { kind: :optional, schema: :boolean },
         optional_integer: { kind: :optional, schema: :integer },
         optional_real: { kind: :optional, schema: :real },
-        optional_code: { kind: :optional, schema: {kind: :code, pattern: /^[0-9]{4}$/ } },
+        optional_code: { kind: :optional, schema: { kind: :code, pattern: /^[0-9]{4}$/ } },
         array_string: { kind: :array, element_schema: :string },
         array_symbol: { kind: :array, element_schema: :symbol },
         array_boolean: { kind: :array, element_schema: :boolean },
         array_integer: { kind: :array, element_schema: :integer },
         array_real: { kind: :array, element_schema: :real },
-        array_code: { kind: :array, element_schema: {kind: :code, pattern: /^[0-9]{4}$/ } },
+        array_code: { kind: :array, element_schema: { kind: :code, pattern: /^[0-9]{4}$/ } }
       }
     )
   end
@@ -147,20 +147,20 @@ RSpec.describe Validator do
     errors = described_class.validate_records(test_data.all, test_data.schema)
 
     expect(errors.keys).to contain_exactly(
-                             'missing fields',
-                             'extra fields',
-                             'wrong string',
-                             'wrong symbol',
-                             'wrong boolean',
-                             'wrong integer',
-                             'wrong real',
-                             'wrong code',
-                             'wrong array 1',
-                             'wrong array 2'
-                           )
-    
+      'missing fields',
+      'extra fields',
+      'wrong string',
+      'wrong symbol',
+      'wrong boolean',
+      'wrong integer',
+      'wrong real',
+      'wrong code',
+      'wrong array 1',
+      'wrong array 2'
+    )
+
     expect(errors['missing fields'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=missing fields>: Field single_string declared as required in the schema, but is missing'
-    expect(errors['extra fields'].to_s).to eq "Validation failed for #<DfE::ReferenceData::Record id=extra fields>: Field undeclared_field not declared in the schema"
+    expect(errors['extra fields'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=extra fields>: Field undeclared_field not declared in the schema'
     expect(errors['wrong string'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=wrong string>: Field single_string does not match the schema string: Value not_a_string is not a string'
     expect(errors['wrong symbol'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=wrong symbol>: Field single_symbol does not match the schema symbol: Value not a symbol is not a symbol'
     expect(errors['wrong boolean'].to_s).to eq 'Validation failed for #<DfE::ReferenceData::Record id=wrong boolean>: Field single_boolean does not match the schema boolean: Value not a boolean is not a boolean'

--- a/spec/support/schema_validation.rb
+++ b/spec/support/schema_validation.rb
@@ -49,28 +49,31 @@ TYPE_CLASSES = {
 class Validator
   def self.validate_pattern_field!(record, field_name, field_schema, value)
     raise InvalidFieldError.new(record, field_name, field_schema, "Value #{value} is not a string") unless value.is_a?(String)
+
     pattern = field_schema[:pattern]
-    raise InvalidSchemaError, "patterns in code schemas must be regexps" unless pattern.is_a?(Regexp)
+    raise InvalidSchemaError, 'patterns in code schemas must be regexps' unless pattern.is_a?(Regexp)
     raise InvalidFieldError.new(record, field_name, field_schema, "Value #{value} does not match the field pattern") unless pattern.match(value)
   end
 
-  def self.validate_simple_field!(record, field_name, field_schema, value)
-    if field_schema.is_a?(Hash)
-      kind = field_schema[:kind]
-      case kind
-      when :code
-        validate_pattern_field!(record, field_name, field_schema, value)
-      else
-        raise InvalidSchemaError, "Unknown simple field schema kind '#{kind}'"
-      end
+  def self.kind(field_schema)
+    case field_schema
+    when Hash
+      field_schema[:kind]
     else
-      if field_schema == :boolean
-        raise InvalidFieldError.new(record, field_name, field_schema, "Value #{value} is not a boolean") unless value.is_a?(TrueClass) || value.is_a?(FalseClass)
-      else
-        desired_class = TYPE_CLASSES[field_schema]
-        raise InvalidSchemaError, "Unknown schema type #{field_schema}" unless desired_class
-        raise InvalidFieldError.new(record, field_name, field_schema, "Value #{value} is not a #{field_schema}") unless value.is_a?(desired_class)
-      end
+      field_schema
+    end
+  end
+
+  def self.validate_simple_field!(record, field_name, field_schema, value)
+    case kind(field_schema)
+    when :code
+      validate_pattern_field!(record, field_name, field_schema, value)
+    when :boolean
+      raise InvalidFieldError.new(record, field_name, field_schema, "Value #{value} is not a boolean") unless value.is_a?(TrueClass) || value.is_a?(FalseClass)
+    else
+      desired_class = TYPE_CLASSES[field_schema]
+      raise InvalidSchemaError, "Unknown schema type #{field_schema}" unless desired_class
+      raise InvalidFieldError.new(record, field_name, field_schema, "Value #{value} is not a #{field_schema}") unless value.is_a?(desired_class)
     end
   end
 
@@ -97,19 +100,15 @@ class Validator
   # Validates a field against a field schema
   # Raises errors if validation fails.
   def self.validate_field!(record, field_name, field_schema, value)
-    case field_schema
-    when Symbol
-      validate_simple_field!(record, field_name, field_schema, value)
-    when Hash
-      kind = field_schema[:kind]
-      case kind
-      when :code
-        validate_simple_field!(record, field_name, field_schema, value)
-      else
-        validate_complex_field!(record, field_name, field_schema, value)
-      end
+    case kind(field_schema)
+    # rubocop:disable Lint/DuplicateBranch
+    when :array
+      validate_complex_field!(record, field_name, field_schema, value)
+    when :optional
+      validate_complex_field!(record, field_name, field_schema, value)
+    # rubocop:enable Lint/DuplicateBranch
     else
-      raise InvalidSchemaError, "Incomprehensible schema '#{field_schema}'"
+      validate_simple_field!(record, field_name, field_schema, value)
     end
   end
 

--- a/spec/support/schema_validation.rb
+++ b/spec/support/schema_validation.rb
@@ -6,7 +6,7 @@ class ValidationError < StandardError
 
   def initialize(message, record)
     @record = record
-    super("Validation failed for #{record}: #{message}")
+    super("Validation failed for #{record.inspect}: #{message}")
   end
 end
 


### PR DESCRIPTION
Added the ability to declare that string fields have to match a certain regexp pattern, useful for fields that are "codes" or "IDs" rather than human readable text.

Also improved the coverage of the schema validator while I was at it, and assigned tighter schemas to the current data where appropriate.