### PR TITLE
Added 'Not known' and 'Not applicable' generic degree subjects

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ BIGQUERY_TABLES = [
   ['qualifications', DfE::ReferenceData::Qualifications::QUALIFICATIONS],
   ['degree_grades', DfE::ReferenceData::Degrees::GRADES],
   ['degree_institutions', DfE::ReferenceData::Degrees::INSTITUTIONS],
-  ['degree_subjects', DfE::ReferenceData::Degrees::SUBJECTS],
+  ['degree_subjects', DfE::ReferenceData::Degrees::SUBJECTS_INCLUDING_GENERICS],
   ['degree_types', DfE::ReferenceData::Degrees::TYPES_INCLUDING_GENERICS],
   ['itt_subjects', DfE::ReferenceData::ITT::SUBJECTS],
   ['itt_incentives', DfE::ReferenceData::ITT::INCENTIVES],

--- a/docs/lists_degrees.md
+++ b/docs/lists_degrees.md
@@ -220,7 +220,7 @@ This list is [autocomplete compatible](autocomplete_compatability.md).
 | Field | Type | Purpose |
 |---|---|---|
 | `id` | UUID | A unique identifier. The same as `dttp_id` if that field is non-`nil`, otherwise a new UUID was minted at import time. |
-| `name` | string | The long name of the subject, eg "accountancy" |
+| `name` | string | The name of the generic category of degree subject, for example "not applicable" |
 | `suggestion_synonyms` | string array | A list of common alternative names that *may* be appropriate for this subject |
 | `match_synonyms` | string array | A list of common alternative names that are equivalent to this subject. An answer matching a match synonym can be safely matched to this subject.|
 | `hecos_code` | optional string | The HESA [DEGSBJ](https://www.hesa.ac.uk/collection/c22053/e/degsbj) code for this degree subject (from [HECoS](https://www.hesa.ac.uk/support/documentation/hecos)) (for single subjects) |

--- a/docs/lists_degrees.md
+++ b/docs/lists_degrees.md
@@ -128,7 +128,7 @@ Degree subjects
 
 Owner: Apply team.
 
-Users: Apply team.
+Users: Apply team, Register team.
 
 Source: https://github.com/DFE-Digital/apply-for-teacher-training-prototype/blob/main/app/data/degree-subjects.js
 
@@ -155,7 +155,7 @@ Common combinations of degree subjects (Eg, subjects of the form "X with Y" or "
 
 Owner: Apply team.
 
-Users: Apply team.
+Users: Apply team, Register team.
 
 Source: https://github.com/DFE-Digital/apply-for-teacher-training-prototype/blob/main/app/data/degree-subjects.js
 
@@ -181,7 +181,7 @@ The union of `SINGLE_SUBJECTS` and `COMBINED_SUBJECTS`.
 
 Owner: Apply team.
 
-Users: Apply team.
+Users: Apply team, Register team.
 
 Source: Automatically derived from joining the `SINGLE_SUBJECTS` and `COMBINED_SUBJECTS` lists.
 
@@ -198,6 +198,60 @@ This list is [autocomplete compatible](autocomplete_compatability.md).
 | `dttp_id` | optional uuid | The ID used for this subject in DTTP (for single subjects) |
 | `hecos_code` | optional string | The HESA [DEGSBJ](https://www.hesa.ac.uk/collection/c22053/e/degsbj) code for this degree subject (from [HECoS](https://www.hesa.ac.uk/support/documentation/hecos)) (for single subjects) |
 | `subject_ids` | optional UUID array | The `SINGLE_SUBJECTS` IDs of the individual parts, in order (for combined subjects) |
+
+### `DfE::ReferenceData::Degrees::GENERIC_SUBJECTS`
+
+```ruby
+require 'dfe/reference_data/degrees'
+```
+
+Generic subject options
+
+Owner: Register team.
+
+Users: Register team.
+
+Source: Manual
+
+Quality: Manually updated on an ad-hoc basis. Please submit a pull request if inaccuracies or omissions are found.
+
+This list is [autocomplete compatible](autocomplete_compatability.md).
+
+| Field | Type | Purpose |
+|---|---|---|
+| `id` | UUID | A unique identifier. The same as `dttp_id` if that field is non-`nil`, otherwise a new UUID was minted at import time. |
+| `name` | string | The long name of the subject, eg "accountancy" |
+| `suggestion_synonyms` | string array | A list of common alternative names that *may* be appropriate for this subject |
+| `match_synonyms` | string array | A list of common alternative names that are equivalent to this subject. An answer matching a match synonym can be safely matched to this subject.|
+| `hecos_code` | optional string | The HESA [DEGSBJ](https://www.hesa.ac.uk/collection/c22053/e/degsbj) code for this degree subject (from [HECoS](https://www.hesa.ac.uk/support/documentation/hecos)) (for single subjects) |
+| `generic` | optional boolean | Always true, to indicate that this is a generic option |
+
+### `DfE::ReferenceData::Degrees::SUBJECTS_INCLUDING_GENERICS`
+
+```ruby
+require 'dfe/reference_data/degrees'
+```
+
+The contents of `SUBJECTS`, plus `GENERIC_SUBJECTS`.
+
+Owner: Register team.
+
+Users: Register team.
+
+Source: Automatically derived from joining the `SINGLE_SUBJECTS` and `COMBINED_SUBJECTS` lists.
+
+Quality: Automatically derived from the source data, so only as correct as they are.
+
+This list is [autocomplete compatible](autocomplete_compatability.md).
+
+| Field | Type | Purpose |
+|---|---|---|
+| `id` | UUID | A unique identifier. The same as `dttp_id` if that field is non-`nil`, otherwise a new UUID was minted at import time. |
+| `name` | string | The long name of the subject, eg "accountancy" |
+| `suggestion_synonyms` | string array | A list of common alternative names that *may* be appropriate for this subject |
+| `match_synonyms` | string array | A list of common alternative names that are equivalent to this subject. An answer matching a match synonym can be safely matched to this subject.|
+| `hecos_code` | optional string | The HESA [DEGSBJ](https://www.hesa.ac.uk/collection/c22053/e/degsbj) code for this degree subject (from [HECoS](https://www.hesa.ac.uk/support/documentation/hecos)) (for single subjects) |
+| `generic` | optional boolean | If present and true, indicates that this is a generic option |
 
 ### `DfE::ReferenceData::Degrees::INSTITUTIONS`
 

--- a/lib/dfe/reference_data/degrees/subjects.rb
+++ b/lib/dfe/reference_data/degrees/subjects.rb
@@ -6,7 +6,8 @@ module DfE
         name: :string,
         suggestion_synonyms: { kind: :array, element_schema: :string },
         match_synonyms: { kind: :array, element_schema: :string },
-        comment: { kind: :optional, schema: :string }
+        comment: { kind: :optional, schema: :string },
+        generic: { kind: :optional, schema: :boolean }
       }.freeze
 
       SINGLE_SUBJECTS_SCHEMA = CORE_SUBJECTS_SCHEMA.merge(
@@ -7094,6 +7095,39 @@ module DfE
         schema: SUBJECTS_SCHEMA,
         list_description: 'Degree subjects, including common combined subjects',
         list_docs_url: 'https://github.com/DFE-Digital/dfe-reference-data/blob/main/docs/lists_degrees.md#dfereferencedatadegreessubjects',
+        field_descriptions: SUBJECTS_FIELD_DESCRIPTIONS
+      )
+
+      GENERIC_SUBJECTS = DfE::ReferenceData::HardcodedReferenceList.new(
+        {
+          '208373a5-8bff-41c8-8b13-3d1d0b34e36e' =>
+          {
+            name: 'Not known',
+            suggestion_synonyms: [],
+            match_synonyms: [],
+            hecos_code: '999999',
+            generic: true
+          },
+          'e84cefde-c18f-478d-8649-a0e5e795d318' =>
+          {
+            name: 'Not applicable',
+            suggestion_synonyms: [],
+            match_synonyms: [],
+            hecos_code: '999998',
+            generic: true
+          }
+        },
+        schema: SUBJECTS_SCHEMA,
+        list_description: 'Generic degree subjects',
+        list_docs_url: 'https://github.com/DFE-Digital/dfe-reference-data/blob/main/docs/lists_degrees.md#dfereferencedatadegreesgenericsubjects',
+        field_descriptions: SUBJECTS_FIELD_DESCRIPTIONS
+      )
+
+      SUBJECTS_INCLUDING_GENERICS = DfE::ReferenceData::JoinedReferenceList.new(
+        [SUBJECTS, GENERIC_SUBJECTS],
+        schema: SUBJECTS_SCHEMA,
+        list_description: 'Degree subjects, including common combined subjects and generic subject options',
+        list_docs_url: 'https://github.com/DFE-Digital/dfe-reference-data/blob/main/docs/lists_degrees.md#dfereferencedatadegreessubjectsincludinggenerics',
         field_descriptions: SUBJECTS_FIELD_DESCRIPTIONS
       )
     end

--- a/lib/dfe/reference_data/degrees/subjects.rb
+++ b/lib/dfe/reference_data/degrees/subjects.rb
@@ -32,7 +32,8 @@ module DfE
         match_synonyms: 'A list of common alternative names that are equivalent to this subject. An answer matching a match synonym can be safely matched to this subject.',
         dttp_id: 'The ID used for this subject in DTTP',
         hecos_code: 'The HESA DEGSBJ code for this degree subject (from [HECoS](https://www.hesa.ac.uk/support/documentation/hecos); see also the [DEGSBJ](https://www.hesa.ac.uk/collection/c22053/e/degsbj) documentation)',
-        subject_ids: 'The subject IDs of the individual single-subject parts of a combined subject'
+        subject_ids: 'The subject IDs of the individual single-subject parts of a combined subject',
+        generic: 'If present and true, indicates that this is a generic option'
       }.freeze
 
       SINGLE_SUBJECTS = DfE::ReferenceData::HardcodedReferenceList.new(

--- a/spec/lib/dfe/reference_data/degrees/subjects_spec.rb
+++ b/spec/lib/dfe/reference_data/degrees/subjects_spec.rb
@@ -12,3 +12,13 @@ RSpec.describe DfE::ReferenceData::Degrees::SUBJECTS do
   it_should_behave_like 'a list of valid records'
   it_should_behave_like 'a valid autocomplete-capable list'
 end
+
+RSpec.describe DfE::ReferenceData::Degrees::GENERIC_SUBJECTS do
+  it_should_behave_like 'a list of valid records'
+  it_should_behave_like 'a valid autocomplete-capable list'
+end
+
+RSpec.describe DfE::ReferenceData::Degrees::SUBJECTS_INCLUDING_GENERICS do
+  it_should_behave_like 'a list of valid records'
+  it_should_behave_like 'a valid autocomplete-capable list'
+end


### PR DESCRIPTION
They're in a separate GENERIC_SUBJECTS list, with a SUBJECTS_INCLUDING_GENERICS that joins them with the standard SUBJECTS list, so services can opt-in to seeing them.