### PR TITLE
Update degree institutions

### DIFF
--- a/lib/dfe/reference_data/degrees/institutions.rb
+++ b/lib/dfe/reference_data/degrees/institutions.rb
@@ -1466,13 +1466,12 @@ module DfE
             dttp_id: '753e182c-1425-ec11-b6e6-000d3adf095a',
             ukprn: '10003958' },
           '0b3f182c-1425-ec11-b6e6-000d3adf095a' =>
-          { name: 'The National Film and Television School',
-            suggestion_synonyms: [],
-            match_synonyms: [],
+          { name: 'National Film and Television School',
+            suggestion_synonyms: ['NFTS'],
+            match_synonyms: ['The National Film and Television School'],
             hesa_itt_code: '0229',
             dttp_id: '0b3f182c-1425-ec11-b6e6-000d3adf095a',
-            ukprn: '10004511',
-            has_never_awarded_degrees: true },
+            ukprn: '10004511' },
           'b53e182c-1425-ec11-b6e6-000d3adf095a' =>
           { name: 'Plymouth College of Art',
             suggestion_synonyms: [],


### PR DESCRIPTION
Updates to our degree institution list following reviewing the Office for Student's spreadsheet of institutions with degree awarding powers, taken today 25 May 2023.

Two institutions were given degree awarding powers in 2023. Both already appear in our reference data list:
* [National television and film school - given degree awarding powers in 2023.](https://www.officeforstudents.org.uk/advice-and-guidance/the-register/the-ofs-register/#/provider/10004511)
* Blackpool and the Fylde College - this probably should have had 'has never awarded degrees' on, but didn't, so not much needed to change now.





























