### PR TITLE
CAH mappings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,11 @@ BIGQUERY_TABLES = [
   ['itt_register_categories', DfE::ReferenceData::ITT::REGISTER_CATEGORIES],
   ['itt_tad_categories', DfE::ReferenceData::ITT::TAD_CATEGORIES],
   ['itt_cycles', DfE::ReferenceData::ITT::CYCLES],
-  ['ead_disabilities_and_health_conditions', DfE::ReferenceData::EqualityAndDiversity::DISABILITIES_AND_HEALTH_CONDITIONS]
+  ['ead_disabilities_and_health_conditions', DfE::ReferenceData::EqualityAndDiversity::DISABILITIES_AND_HEALTH_CONDITIONS],
+  ['cah_categories_l1', DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L1],
+  ['cah_categories_l2', DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L2],
+  ['cah_categories_l3', DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L3],
+  ['hecos_cah_subject_mappings', DfE::ReferenceData::CommonAggregationHierarchy::HECOS_CAH_SUBJECT_MAPPINGS]
 ].freeze
 
 desc 'Insert records into BigQuery tables from the reference data lists'

--- a/docs/lists_itt.md
+++ b/docs/lists_itt.md
@@ -127,6 +127,11 @@ Quality: Manually updated on an ad-hoc basis. Please submit a pull request if in
 | `phase` | symbol (`primary` or `secondary`) | The phase of this TAD category |
 | `other_id` | string ID | An additional `ID` field found in the source spreadsheet, purpose unknown |
 | `register_name` | string | The corresponding subject name as believed to be found in Register, according to the author of the spreadsheet |
+| `cah_associated_mappings_allow` | ID string array | A list of CAH level 1, 2 or 3 codes or degree subject IDs for subjects that potentially correspond to this TAD category, unless a match in cah_associated_mappings_block is found. |
+| `cah_associated_mappings_block` | ID string array | A list of CAH level 1, 2 or 3 codes or degree subject IDs  for subjects that do NOT even potentially correspond to this TAD category, but would otherwise be matched by a more generic code in cah_associated_mappings_allow |
+| `cah_direct_mappings_allow` | ID string array | A list of CAH level 1, 2 or 3 codes or degree subject IDs for subjects that directly correspond to this TAD category, unless a match in cah_associated_mappings_block is found. |
+| `cah_direct_mappings_block` | ID string array | A list of CAH level 1, 2 or 3 codes or degree subject IDs for subjects that do NOT directly correspond to this TAD category, but would otherwise be matched by a more generic code in cah_associated_mappings_allow |
+
 
 ### `DfE::ReferenceData::ITT::INCENTIVES`
 

--- a/lib/dfe/reference_data/itt/subjects.rb
+++ b/lib/dfe/reference_data/itt/subjects.rb
@@ -67,7 +67,10 @@ module DfE
         register_name: :string,
         type: :symbol,
         phase: :symbol,
-        other_id: :string
+        other_id: :string,
+
+        cah_mappings_allow: { kind: :array, element_schema: :string },
+        cah_mappings_block: { kind: :array, element_schema: :string }
       }.freeze
 
       TAD_CATEGORIES_FIELD_DESCRIPTIONS = {
@@ -79,7 +82,9 @@ module DfE
         type: 'The type of this subject category',
         phase: 'The phase (age range) of this subject category',
         other_id: '(unknown)',
-        register_name: 'The corresponding subject name as believed to be found in Register, according to the author of the spreadsheet (probably not useful, pending removal after review)'
+        register_name: 'The corresponding subject name as believed to be found in Register, according to the author of the spreadsheet (probably not useful, pending removal after review)',
+        cah_mappings_allow: 'A list of CAH level 1, 2 or 3 codes for subjects that potentially correspond to this TAD category, unless a match in cah_mappings_block is found.',
+        cah_mappings_block: 'A list of CAH level 1, 2 or 3 codes for subjects that do NOT even potentially correspond to this TAD category, but would otherwise be matched by a more generic code in cah_mappings_allow'
       }.freeze
 
       # From https://docs.google.com/spreadsheets/d/152PMbCj_bmnm8rmqVFLJAA2Hu8-9pkPjDmGyOi85768/edit#gid=2053127863&range=Q85
@@ -1037,7 +1042,10 @@ module DfE
                     register_name: 'Primary with science',
                     type: :primary,
                     phase: :primary,
-                    other_id: '7' },
+                    other_id: '7',
+
+                    cah_mappings_allow: [],
+                    cah_mappings_block: [] },
 
           '1' => { name: 'Art & Design',
                    publish_category: 'W1',
@@ -1047,7 +1055,10 @@ module DfE
                    register_name: 'Art and design',
                    type: :secondary,
                    phase: :secondary,
-                   other_id: '8' },
+                   other_id: '8',
+
+                   cah_mappings_allow: ['CAH25'],
+                   cah_mappings_block: [] },
 
           '18' => { name: 'Physics',
                     publish_category: 'F3',
@@ -1057,7 +1068,10 @@ module DfE
                     register_name: 'Physics',
                     type: :secondary,
                     phase: :secondary,
-                    other_id: '29' },
+                    other_id: '29',
+
+                    cah_mappings_allow: ['CAH10', 'CAH09', 'CAH07'],
+                    cah_mappings_block: [] },
 
           '2' => { name: 'Biology',
                    publish_category: nil,
@@ -1067,7 +1081,10 @@ module DfE
                    register_name: 'Balanced Science',
                    type: :discontinued,
                    phase: :secondary,
-                   other_id: '45' },
+                   other_id: '45',
+
+                   cah_mappings_allow: ['CAH03', 'CAH07'],
+                   cah_mappings_block: [] },
 
           '3' => { name: 'Business Studies',
                    publish_category: 'L1',
@@ -1077,7 +1094,10 @@ module DfE
                    register_name: 'Economics',
                    type: :secondary,
                    phase: :secondary,
-                   other_id: '20' },
+                   other_id: '20',
+
+                   cah_mappings_allow: ['CAH17'],
+                   cah_mappings_block: [] },
 
           '4' => { name: 'Chemistry',
                    publish_category: 'F1',
@@ -1087,7 +1107,10 @@ module DfE
                    register_name: 'Chemistry',
                    type: :secondary,
                    phase: :secondary,
-                   other_id: '12' },
+                   other_id: '12',
+
+                   cah_mappings_allow: ['CAH10', 'CAH09', 'CAH07'],
+                   cah_mappings_block: [] },
 
           '16' => { name: 'Others',
                     publish_category: nil,
@@ -1097,7 +1120,10 @@ module DfE
                     register_name: 'Humanities',
                     type: :discontinued,
                     phase: :secondary,
-                    other_id: '44' },
+                    other_id: '44',
+
+                    cah_mappings_allow: [],
+                    cah_mappings_block: [] },
 
           '5' => { name: 'Classics',
                    publish_category: 'Q8',
@@ -1107,7 +1133,10 @@ module DfE
                    register_name: 'Classics',
                    type: :secondary,
                    phase: :secondary,
-                   other_id: '14' },
+                   other_id: '14',
+
+                   cah_mappings_allow: ['CAH20'],
+                   cah_mappings_block: [] },
 
           '6' => { name: 'Computing',
                    publish_category: '11',
@@ -1117,7 +1146,10 @@ module DfE
                    register_name: 'Computing',
                    type: :secondary,
                    phase: :secondary,
-                   other_id: '16' },
+                   other_id: '16',
+
+                   cah_mappings_allow: ['CAH11', 'CAH10'],
+                   cah_mappings_block: [] },
 
           '17' => { name: 'Physical education',
                     publish_category: 'C6',
@@ -1127,7 +1159,10 @@ module DfE
                     register_name: 'Physical education',
                     type: :secondary,
                     phase: :secondary,
-                    other_id: '28' },
+                    other_id: '28',
+
+                    cah_mappings_allow: ['CAH03'],
+                    cah_mappings_block: [] },
 
           '7' => { name: 'Design & Technology',
                    publish_category: 'DT',
@@ -1137,7 +1172,10 @@ module DfE
                    register_name: 'Design and technology',
                    type: :secondary,
                    phase: :secondary,
-                   other_id: '18' },
+                   other_id: '18',
+
+                   cah_mappings_allow: ['CAH25'],
+                   cah_mappings_block: [] },
 
           '8' => { name: 'Drama',
                    publish_category: '13',
@@ -1147,7 +1185,10 @@ module DfE
                    register_name: 'Drama',
                    type: :secondary,
                    phase: :secondary,
-                   other_id: '19' },
+                   other_id: '19',
+
+                   cah_mappings_allow: ['CAH25'],
+                   cah_mappings_block: [] },
 
           '9' => { name: 'English',
                    publish_category: 'Q3',
@@ -1157,7 +1198,10 @@ module DfE
                    register_name: 'English',
                    type: :secondary,
                    phase: :secondary,
-                   other_id: '21' },
+                   other_id: '21',
+
+                   cah_mappings_allow: ['CAH19', 'CAH24'],
+                   cah_mappings_block: [] },
 
           '10' => { name: 'Geography',
                     publish_category: 'F8',
@@ -1167,7 +1211,10 @@ module DfE
                     register_name: 'Geography',
                     type: :secondary,
                     phase: :secondary,
-                    other_id: '22' },
+                    other_id: '22',
+
+                    cah_mappings_allow: ['CAH26'],
+                    cah_mappings_block: [] },
 
           '11' => { name: 'History',
                     publish_category: 'V1',
@@ -1177,7 +1224,10 @@ module DfE
                     register_name: 'History',
                     type: :secondary,
                     phase: :secondary,
-                    other_id: '24' },
+                    other_id: '24',
+
+                    cah_mappings_allow: ['CAH20'],
+                    cah_mappings_block: [] },
 
           '12' => { name: 'Mathematics',
                     publish_category: 'G1',
@@ -1187,7 +1237,10 @@ module DfE
                     register_name: 'Mathematics',
                     type: :secondary,
                     phase: :secondary,
-                    other_id: '25' },
+                    other_id: '25',
+
+                    cah_mappings_allow: ['CAH10', 'CAH09', 'CAH07', 'CAH15-02'],
+                    cah_mappings_block: [] },
 
           '14' => { name: 'Music',
                     publish_category: 'W3',
@@ -1197,7 +1250,10 @@ module DfE
                     register_name: 'Music',
                     type: :secondary,
                     phase: :secondary,
-                    other_id: '26' },
+                    other_id: '26',
+
+                    cah_mappings_allow: ['CAH25'],
+                    cah_mappings_block: [] },
 
           '20' => { name: 'Religious Education',
                     publish_category: 'V6',
@@ -1207,7 +1263,10 @@ module DfE
                     register_name: 'Religious education',
                     type: :secondary,
                     phase: :secondary,
-                    other_id: '31' },
+                    other_id: '31',
+
+                    cah_mappings_allow: ['CAH20'],
+                    cah_mappings_block: [] },
 
           '13' => { name: 'Modern Foreign Languages',
                     publish_category: '24',
@@ -1217,7 +1276,10 @@ module DfE
                     register_name: 'Modern languages (other)',
                     type: :modern_languages,
                     phase: :secondary,
-                    other_id: '42' }
+                    other_id: '42',
+
+                    cah_mappings_allow: ['CAH19'],
+                    cah_mappings_block: [] }
         },
         schema: TAD_CATEGORIES_SCHEMA,
         list_description: 'Initial teacher training subject categories, as currently used by TAD.',

--- a/lib/dfe/reference_data/itt/subjects.rb
+++ b/lib/dfe/reference_data/itt/subjects.rb
@@ -69,8 +69,10 @@ module DfE
         phase: :symbol,
         other_id: :string,
 
-        cah_mappings_allow: { kind: :array, element_schema: :string },
-        cah_mappings_block: { kind: :array, element_schema: :string }
+        cah_associated_mappings_allow: { kind: :array, element_schema: :string },
+        cah_associated_mappings_block: { kind: :array, element_schema: :string },
+        cah_direct_mappings_allow: { kind: :array, element_schema: :string },
+        cah_direct_mappings_block: { kind: :array, element_schema: :string }
       }.freeze
 
       TAD_CATEGORIES_FIELD_DESCRIPTIONS = {
@@ -83,8 +85,10 @@ module DfE
         phase: 'The phase (age range) of this subject category',
         other_id: '(unknown)',
         register_name: 'The corresponding subject name as believed to be found in Register, according to the author of the spreadsheet (probably not useful, pending removal after review)',
-        cah_mappings_allow: 'A list of CAH level 1, 2 or 3 codes for subjects that potentially correspond to this TAD category, unless a match in cah_mappings_block is found.',
-        cah_mappings_block: 'A list of CAH level 1, 2 or 3 codes for subjects that do NOT even potentially correspond to this TAD category, but would otherwise be matched by a more generic code in cah_mappings_allow'
+        cah_associated_mappings_allow: 'A list of CAH level 1, 2 or 3 codes or degree subject IDs for subjects that potentially correspond to this TAD category, unless a match in cah_associated_mappings_block is found.',
+        cah_associated_mappings_block: 'A list of CAH level 1, 2 or 3 codes or degree subject IDs  for subjects that do NOT even potentially correspond to this TAD category, but would otherwise be matched by a more generic code in cah_associated_mappings_allow',
+        cah_direct_mappings_allow: 'A list of CAH level 1, 2 or 3 codes or degree subject IDs for subjects that directly correspond to this TAD category, unless a match in cah_associated_mappings_block is found.',
+        cah_direct_mappings_block: 'A list of CAH level 1, 2 or 3 codes or degree subject IDs for subjects that do NOT directly correspond to this TAD category, but would otherwise be matched by a more generic code in cah_associated_mappings_allow'
       }.freeze
 
       # From https://docs.google.com/spreadsheets/d/152PMbCj_bmnm8rmqVFLJAA2Hu8-9pkPjDmGyOi85768/edit#gid=2053127863&range=Q85
@@ -1044,8 +1048,11 @@ module DfE
                     phase: :primary,
                     other_id: '7',
 
-                    cah_mappings_allow: [],
-                    cah_mappings_block: [] },
+                    cah_associated_mappings_allow: [],
+                    cah_associated_mappings_block: [],
+
+                    cah_direct_mappings_allow: [],
+                    cah_direct_mappings_block: [] },
 
           '1' => { name: 'Art & Design',
                    publish_category: 'W1',
@@ -1057,8 +1064,11 @@ module DfE
                    phase: :secondary,
                    other_id: '8',
 
-                   cah_mappings_allow: ['CAH25'],
-                   cah_mappings_block: [] },
+                   cah_associated_mappings_allow: ['CAH25'],
+                   cah_associated_mappings_block: [],
+
+                   cah_direct_mappings_allow: ['CAH25-01'],
+                   cah_direct_mappings_block: [] },
 
           '18' => { name: 'Physics',
                     publish_category: 'F3',
@@ -1070,8 +1080,11 @@ module DfE
                     phase: :secondary,
                     other_id: '29',
 
-                    cah_mappings_allow: ['CAH10', 'CAH09', 'CAH07'],
-                    cah_mappings_block: [] },
+                    cah_associated_mappings_allow: ['CAH10', 'CAH09', 'CAH07'],
+                    cah_associated_mappings_block: [],
+
+                    cah_direct_mappings_allow: ['CAH07-01'],
+                    cah_direct_mappings_block: [] },
 
           '2' => { name: 'Biology',
                    publish_category: nil,
@@ -1083,8 +1096,11 @@ module DfE
                    phase: :secondary,
                    other_id: '45',
 
-                   cah_mappings_allow: ['CAH03', 'CAH07'],
-                   cah_mappings_block: [] },
+                   cah_associated_mappings_allow: ['CAH03', 'CAH07'],
+                   cah_associated_mappings_block: [],
+
+                   cah_direct_mappings_allow: ['CAH03-01'],
+                   cah_direct_mappings_block: [] },
 
           '3' => { name: 'Business Studies',
                    publish_category: 'L1',
@@ -1096,8 +1112,11 @@ module DfE
                    phase: :secondary,
                    other_id: '20',
 
-                   cah_mappings_allow: ['CAH17'],
-                   cah_mappings_block: [] },
+                   cah_associated_mappings_allow: ['CAH17'],
+                   cah_associated_mappings_block: [],
+
+                   cah_direct_mappings_allow: ['CAH17'],
+                   cah_direct_mappings_block: [] },
 
           '4' => { name: 'Chemistry',
                    publish_category: 'F1',
@@ -1109,8 +1128,11 @@ module DfE
                    phase: :secondary,
                    other_id: '12',
 
-                   cah_mappings_allow: ['CAH10', 'CAH09', 'CAH07'],
-                   cah_mappings_block: [] },
+                   cah_associated_mappings_allow: ['CAH10', 'CAH09', 'CAH07'],
+                   cah_associated_mappings_block: [],
+
+                   cah_direct_mappings_allow: ['CAH07-02'],
+                   cah_direct_mappings_block: [] },
 
           '16' => { name: 'Others',
                     publish_category: nil,
@@ -1122,8 +1144,11 @@ module DfE
                     phase: :secondary,
                     other_id: '44',
 
-                    cah_mappings_allow: [],
-                    cah_mappings_block: [] },
+                    cah_associated_mappings_allow: ['CAH01', 'CAH02', 'CAH04', 'CAH05', 'CAH06', 'CAH13', 'CAH15', 'CAH16', 'CAH22', 'CAH23', 'CAHZ5'],
+                    cah_associated_mappings_block: ['CAH15-02'],
+
+                    cah_direct_mappings_allow: [],
+                    cah_direct_mappings_block: [] },
 
           '5' => { name: 'Classics',
                    publish_category: 'Q8',
@@ -1135,8 +1160,11 @@ module DfE
                    phase: :secondary,
                    other_id: '14',
 
-                   cah_mappings_allow: ['CAH20'],
-                   cah_mappings_block: [] },
+                   cah_associated_mappings_allow: ['CAH20'],
+                   cah_associated_mappings_block: [],
+
+                   cah_direct_mappings_allow: ['CAH20-01-05'],
+                   cah_direct_mappings_block: [] },
 
           '6' => { name: 'Computing',
                    publish_category: '11',
@@ -1148,8 +1176,11 @@ module DfE
                    phase: :secondary,
                    other_id: '16',
 
-                   cah_mappings_allow: ['CAH11', 'CAH10'],
-                   cah_mappings_block: [] },
+                   cah_associated_mappings_allow: ['CAH11', 'CAH10'],
+                   cah_associated_mappings_block: [],
+
+                   cah_direct_mappings_allow: ['CAH11'],
+                   cah_direct_mappings_block: [] },
 
           '17' => { name: 'Physical education',
                     publish_category: 'C6',
@@ -1161,8 +1192,11 @@ module DfE
                     phase: :secondary,
                     other_id: '28',
 
-                    cah_mappings_allow: ['CAH03'],
-                    cah_mappings_block: [] },
+                    cah_associated_mappings_allow: ['CAH03'],
+                    cah_associated_mappings_block: [],
+
+                    cah_direct_mappings_allow: ['CAH03-02'],
+                    cah_direct_mappings_block: [] },
 
           '7' => { name: 'Design & Technology',
                    publish_category: 'DT',
@@ -1174,8 +1208,11 @@ module DfE
                    phase: :secondary,
                    other_id: '18',
 
-                   cah_mappings_allow: ['CAH25'],
-                   cah_mappings_block: [] },
+                   cah_associated_mappings_allow: ['CAH10', 'CAH25'],
+                   cah_associated_mappings_block: [],
+
+                   cah_direct_mappings_allow: ['CAH10'],
+                   cah_direct_mappings_block: [] },
 
           '8' => { name: 'Drama',
                    publish_category: '13',
@@ -1187,8 +1224,11 @@ module DfE
                    phase: :secondary,
                    other_id: '19',
 
-                   cah_mappings_allow: ['CAH25'],
-                   cah_mappings_block: [] },
+                   cah_associated_mappings_allow: ['CAH25'],
+                   cah_associated_mappings_block: [],
+
+                   cah_direct_mappings_allow: ['CAH25-02-03'],
+                   cah_direct_mappings_block: [] },
 
           '9' => { name: 'English',
                    publish_category: 'Q3',
@@ -1200,8 +1240,11 @@ module DfE
                    phase: :secondary,
                    other_id: '21',
 
-                   cah_mappings_allow: ['CAH19', 'CAH24'],
-                   cah_mappings_block: [] },
+                   cah_associated_mappings_allow: ['CAH19', 'CAH24'],
+                   cah_associated_mappings_block: [],
+
+                   cah_direct_mappings_allow: ['CAH19-01'],
+                   cah_direct_mappings_block: [] },
 
           '10' => { name: 'Geography',
                     publish_category: 'F8',
@@ -1213,8 +1256,11 @@ module DfE
                     phase: :secondary,
                     other_id: '22',
 
-                    cah_mappings_allow: ['CAH26'],
-                    cah_mappings_block: [] },
+                    cah_associated_mappings_allow: ['CAH26'],
+                    cah_associated_mappings_block: [],
+
+                    cah_direct_mappings_allow: ['CAH26'],
+                    cah_direct_mappings_block: [] },
 
           '11' => { name: 'History',
                     publish_category: 'V1',
@@ -1226,8 +1272,11 @@ module DfE
                     phase: :secondary,
                     other_id: '24',
 
-                    cah_mappings_allow: ['CAH20'],
-                    cah_mappings_block: [] },
+                    cah_associated_mappings_allow: ['CAH20'],
+                    cah_associated_mappings_block: [],
+
+                    cah_direct_mappings_allow: ['CAH20-01'],
+                    cah_direct_mappings_block: [] },
 
           '12' => { name: 'Mathematics',
                     publish_category: 'G1',
@@ -1239,8 +1288,11 @@ module DfE
                     phase: :secondary,
                     other_id: '25',
 
-                    cah_mappings_allow: ['CAH10', 'CAH09', 'CAH07', 'CAH15-02'],
-                    cah_mappings_block: [] },
+                    cah_associated_mappings_allow: ['CAH10', 'CAH09', 'CAH07', 'CAH15-02'],
+                    cah_associated_mappings_block: [],
+
+                    cah_direct_mappings_allow: ['CAH09'],
+                    cah_direct_mappings_block: [] },
 
           '14' => { name: 'Music',
                     publish_category: 'W3',
@@ -1252,8 +1304,11 @@ module DfE
                     phase: :secondary,
                     other_id: '26',
 
-                    cah_mappings_allow: ['CAH25'],
-                    cah_mappings_block: [] },
+                    cah_associated_mappings_allow: ['CAH25'],
+                    cah_associated_mappings_block: [],
+
+                    cah_direct_mappings_allow: ['CAH25-02-02'],
+                    cah_direct_mappings_block: [] },
 
           '20' => { name: 'Religious Education',
                     publish_category: 'V6',
@@ -1265,8 +1320,11 @@ module DfE
                     phase: :secondary,
                     other_id: '31',
 
-                    cah_mappings_allow: ['CAH20'],
-                    cah_mappings_block: [] },
+                    cah_associated_mappings_allow: ['CAH20'],
+                    cah_associated_mappings_block: [],
+
+                    cah_direct_mappings_allow: ['CAH20-02'],
+                    cah_direct_mappings_block: [] },
 
           '13' => { name: 'Modern Foreign Languages',
                     publish_category: '24',
@@ -1278,8 +1336,11 @@ module DfE
                     phase: :secondary,
                     other_id: '42',
 
-                    cah_mappings_allow: ['CAH19'],
-                    cah_mappings_block: [] }
+                    cah_associated_mappings_allow: ['CAH19'],
+                    cah_associated_mappings_block: [],
+
+                    cah_direct_mappings_allow: ['CAH19-04'],
+                    cah_direct_mappings_block: [] }
         },
         schema: TAD_CATEGORIES_SCHEMA,
         list_description: 'Initial teacher training subject categories, as currently used by TAD.',

--- a/spec/lib/dfe/reference_data/itt/subjects_spec.rb
+++ b/spec/lib/dfe/reference_data/itt/subjects_spec.rb
@@ -121,22 +121,36 @@ RSpec.describe DfE::ReferenceData::ITT::TAD_CATEGORIES do
   it 'has a valid cah_mappings_allow list' do
     expect(records).to be_all do |rec|
       name = rec.name
-      allow_list = rec.cah_mappings_allow
-      block_list = rec.cah_mappings_block
+      associated_allow_list = rec.cah_associated_mappings_allow
+      associated_block_list = rec.cah_associated_mappings_block
+      direct_allow_list = rec.cah_direct_mappings_allow
+      direct_block_list = rec.cah_direct_mappings_block
 
-      allow_list_good = allow_list.all? do |cah|
+      associated_allow_list_good = associated_allow_list.all? do |cah|
         good = (l1.include?(cah) or l2.include?(cah) or l3.include?(cah))
-        puts "ERROR: TAD Category '#{name}' has a cah_mappings_allow entry '#{cah}' which is not found in any of DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L[1,2,3]" unless good
+        puts "ERROR: TAD Category '#{name}' has a cah_associated_mappings_allow entry '#{cah}' which is not found in any of DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L[1,2,3]" unless good
         good
       end
 
-      block_list_good = block_list.all? do |cah|
+      associated_block_list_good = associated_block_list.all? do |cah|
         good = (l1.include?(cah) or l2.include?(cah) or l3.include?(cah))
-        puts "ERROR: TAD Category '#{name}' has a cah_mappings_block entry '#{cah}' which is not found in any of DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L[1,2,3]" unless good
+        puts "ERROR: TAD Category '#{name}' has a cah_associated_mappings_block entry '#{cah}' which is not found in any of DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L[1,2,3]" unless good
         good
       end
 
-      allow_list_good and block_list_good
+      direct_allow_list_good = direct_allow_list.all? do |cah|
+        good = (l1.include?(cah) or l2.include?(cah) or l3.include?(cah))
+        puts "ERROR: TAD Category '#{name}' has a cah_direct_mappings_allow entry '#{cah}' which is not found in any of DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L[1,2,3]" unless good
+        good
+      end
+
+      direct_block_list_good = direct_block_list.all? do |cah|
+        good = (l1.include?(cah) or l2.include?(cah) or l3.include?(cah))
+        puts "ERROR: TAD Category '#{name}' has a cah_direct_mappings_block entry '#{cah}' which is not found in any of DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L[1,2,3]" unless good
+        good
+      end
+
+      associated_allow_list_good and associated_block_list_good and direct_allow_list_good and direct_block_list_good
     end
   end
 end

--- a/spec/lib/dfe/reference_data/itt/subjects_spec.rb
+++ b/spec/lib/dfe/reference_data/itt/subjects_spec.rb
@@ -112,6 +112,33 @@ end
 
 RSpec.describe DfE::ReferenceData::ITT::TAD_CATEGORIES do
   it_should_behave_like 'a list of valid records'
+
+  let(:records) { described_class.all }
+  let(:l1) { DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L1.all_as_hash }
+  let(:l2) { DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L2.all_as_hash }
+  let(:l3) { DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L3.all_as_hash }
+
+  it 'has a valid cah_mappings_allow list' do
+    expect(records).to be_all do |rec|
+      name = rec.name
+      allow_list = rec.cah_mappings_allow
+      block_list = rec.cah_mappings_block
+
+      allow_list_good = allow_list.all? do |cah|
+        good = (l1.include?(cah) or l2.include?(cah) or l3.include?(cah))
+        puts "ERROR: TAD Category '#{name}' has a cah_mappings_allow entry '#{cah}' which is not found in any of DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L[1,2,3]" unless good
+        good
+      end
+
+      block_list_good = block_list.all? do |cah|
+        good = (l1.include?(cah) or l2.include?(cah) or l3.include?(cah))
+        puts "ERROR: TAD Category '#{name}' has a cah_mappings_block entry '#{cah}' which is not found in any of DfE::ReferenceData::CommonAggregationHierarchy::CAH_CATEGORIES_L[1,2,3]" unless good
+        good
+      end
+
+      allow_list_good and block_list_good
+    end
+  end
 end
 
 RSpec.describe DfE::ReferenceData::ITT::CATEGORIES do


### PR DESCRIPTION
This adds columns to `TAD_SUBJECTS` that map those to CAH categories (so they can, in turn, be linked through to HECoS codes for degree subjects).

We get two levels of match - direct and associated - depending on how "close" the connection is.

The data source is hand-edited data provided to me from various sources, merged together, and some common sense used to paper over the cracks.

We use a block list and an allow list, allowing a TAD subject to be associated with CAH categories at levels 1, 2 or 3 or direct to a particular degree subject ID (from `Degrees::SUBJECTS`) if we need to get really fine-grained. The block list and individual-subject-level functionality isn't used in the mappings so far, but I'm building it into the query that will consume this data so it's easy for people to add finer-grained distinctions in future without needing to rewrite my SQL.