### PR TITLE
Tidy importer_spec.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pkg
 .bundle/config
 vendor/bundle
+lib/dfe/reference_data/bigquery/*.json

--- a/lib/dfe/reference_data/bigquery/importer.rb
+++ b/lib/dfe/reference_data/bigquery/importer.rb
@@ -31,11 +31,12 @@ module DfE
 
         # rubocop:disable Style/ClassVars
         def self.obtain_credentials
+          expanded_path = File.expand_path('dfe-reference-data_bigquery_api_key.json', __dir__)
           if @@credentials.nil?
             if ENV['BIGQUERY_CREDENTIALS']
               @@credentials = JSON.parse(ENV['BIGQUERY_CREDENTIALS'])
-            elsif File.file?('../dfe-reference-data_bigquery_api_key.json')
-              @@credentials = JSON.parse(File.read('../dfe-reference-data_bigquery_api_key.json'))
+            elsif File.file?(expanded_path)
+              @@credentials = JSON.parse(File.read(expanded_path))
             else
               raise StandardError, 'No bigquery credentials were found in $BIGQUERY_CREDENTIALS or ../dfe-reference-data_bigquery_api_key.json'
             end

--- a/spec/lib/dfe/reference_data/bigquery/importer_spec.rb
+++ b/spec/lib/dfe/reference_data/bigquery/importer_spec.rb
@@ -18,7 +18,7 @@ DfE::ReferenceData::BigQuery::Config.configure do |config|
 end
 
 # Omit this test if we don't have credentials available
-if DfE::ReferenceData::BigQuery::Config.obtain_credentials
+if DfE::ReferenceData::BigQuery::Config.obtain_credentials.any?
   RSpec.describe DfE::ReferenceData::BigQuery do
     let(:test_data) do
       DfE::ReferenceData::HardcodedReferenceList.new(
@@ -219,4 +219,6 @@ if DfE::ReferenceData::BigQuery::Config.obtain_credentials
                                      ['single_symbol', nil])
     end
   end
+else
+  puts 'BigQuery credentials missing: Add credentials for importer_spec.rb to run'
 end


### PR DESCRIPTION
1. Currently if credentials are missing the importer_spec.rb raises a credentials missing error and the rest of the tests fail to run. This PR proposes a different way of handling this scenario which can be annoying if you are new to the project - instead a message is printed to the console to remind the user to add credentials for the importer spec to run and a conditional allows the rest of the tests to run

2. An update to the file path in the `importer.rb` so that the .json file can be found

3. Add .json file to .gitignore - to prevent this file being committed accidentally
