### PR TITLE
v2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v2.4.0](https://github.com/DFE-Digital/dfe-reference-data/tree/v2.4.0) (2023-12-18)
+
+**Merged pull requests:**
+
+- Updates notes for Classical Greek studies [\#93](https://github.com/DFE-Digital/dfe-reference-data/pull/93)
+
+- Add bank holidays to the gem [\#92](https://github.com/DFE-Digital/dfe-reference-data/pull/92)
+
 ## [v2.3.3](https://github.com/DFE-Digital/dfe-reference-data/tree/v2.3.3) (2023-11-23)
 
 **Merged pull requests:**

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dfe-reference-data (2.3.3)
+    dfe-reference-data (2.4.0)
       activesupport
       tzinfo
 

--- a/lib/dfe/reference_data/version.rb
+++ b/lib/dfe/reference_data/version.rb
@@ -1,5 +1,5 @@
 module DfE
   module ReferenceData
-    VERSION = '2.3.3'.freeze
+    VERSION = '2.4.0'.freeze
   end
 end


### PR DESCRIPTION
This version includes:

- Updates notes for Classical Greek studies [\#93](https://github.com/DFE-Digital/dfe-reference-data/pull/93) - a minor update

- Add bank holidays to the gem [\#92](https://github.com/DFE-Digital/dfe-reference-data/pull/92) - a non-breaking change - adds a new class to the gem which primarily will be used in Dataform for non working days query