### PR TITLE
Prepare release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v3.0.0](https://github.com/DFE-Digital/dfe-reference-data/tree/v2.4.0) (2023-12-18)
+
+**Merged pull requests:**
+
+- Add russell group info to institutions [\#91](https://github.com/DFE-Digital/dfe-reference-data/pull/91)
+
 ## [v2.4.0](https://github.com/DFE-Digital/dfe-reference-data/tree/v2.4.0) (2023-12-18)
 
 **Merged pull requests:**

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dfe-reference-data (2.4.0)
+    dfe-reference-data (3.0.0)
       activesupport
       tzinfo
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ Until we sort out our RubyGems account, dependents will pull the gem from GitHub
 
 When moving to a new breaking release (the first part of the version number changes), you might need to make changes to your code that uses the lists. This section explains all.
 
+### v2.x -> v3.x
+
+#### Adding fields into the institutions hash
+
+Two new fields have been added into the institutions hash: `institution_groups: { kind: :array, element_schema: :string } and postcode: { kind: :optional, schema: :string }`. These changes might not be backwards compatible and you may need to make updates to your code.
+
 ### v1.x -> v2.x
 
 #### Zero-padded HESA codes

--- a/lib/dfe/reference_data/version.rb
+++ b/lib/dfe/reference_data/version.rb
@@ -1,5 +1,5 @@
 module DfE
   module ReferenceData
-    VERSION = '2.4.0'.freeze
+    VERSION = '3.0.0'.freeze
   end
 end


### PR DESCRIPTION
Two new fields have been added into the institutions hash: `institution_groups: { kind: :array, element_schema: :string } and postcode: { kind: :optional, schema: :string }`. For some projects, this might be a breaking change