### PR TITLE
Release v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v3.5.0](https://github.com/DFE-Digital/dfe-reference-data/tree/v3.5.0) (2024-07-08)
+
+**Merged pull requests:**
+
+- Allow BQ tables to be suffixed with _latest [\#110](https://github.com/DFE-Digital/dfe-reference-data/pull/110)
+
 ## [v3.4.0](https://github.com/DFE-Digital/dfe-reference-data/tree/v3.4.0) (2024-06-07)
 
 **Merged pull requests:**

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dfe-reference-data (3.4.0)
+    dfe-reference-data (3.5.0)
       activesupport
       tzinfo
 

--- a/lib/dfe/reference_data/version.rb
+++ b/lib/dfe/reference_data/version.rb
@@ -1,5 +1,5 @@
 module DfE
   module ReferenceData
-    VERSION = '3.4.0'.freeze
+    VERSION = '3.5.0'.freeze
   end
 end


### PR DESCRIPTION
- Allow BQ tables to be suffixed with _latest [\#110](https://github.com/DFE-Digital/dfe-reference-data/pull/110)