### PR TITLE
Add converter.rb and update Rakefile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,10 @@ jobs:
           BIGQUERY_CREDENTIALS: ${{ secrets.BIGQUERY_CREDENTIALS }}
           BIGQUERY_PROJECT: cross-teacher-services
           BIGQUERY_DATASET: dfe_reference_data
+      - name: Convert Reference Data to SQLite
+        run: bundle exec rake convert_to_sqlite
+      - name: Upload SQLite Database
+        uses: actions/upload-artifact@v2
+        with:
+          name: reference_data_db_${{ secrets.VERSION }}
+          path: reference_data_${{ secrets.VERSION }}.db

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,20 +8,22 @@ jobs:
   run-rake:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '2.7.0'
-          bundler-cache: true
-      - run: bundle exec rake update_bigquery_tables
-        env:
-          BIGQUERY_CREDENTIALS: ${{ secrets.BIGQUERY_CREDENTIALS }}
-          BIGQUERY_PROJECT: cross-teacher-services
-          BIGQUERY_DATASET: dfe_reference_data
-      - name: Convert Reference Data to SQLite
-        run: bundle exec rake convert_to_sqlite
-      - name: Upload SQLite Database
-        uses: actions/upload-artifact@v2
-        with:
-          name: reference_data_db_${{ secrets.VERSION }}
-          path: reference_data_${{ secrets.VERSION }}.db
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7.0'
+        bundler-cache: true
+    - name: Install SQLite3 Gem
+      run: gem install sqlite3 -v '~> 1.4.0'
+    - run: bundle exec rake update_bigquery_tables
+      env:
+        BIGQUERY_CREDENTIALS: ${{ secrets.BIGQUERY_CREDENTIALS }}
+        BIGQUERY_PROJECT: cross-teacher-services
+        BIGQUERY_DATASET: dfe_reference_data
+    - name: Convert Reference Data to SQLite
+      run: bundle exec rake convert_to_sqlite
+    - name: Upload SQLite Database
+      uses: actions/upload-artifact@v4
+      with:
+        name: reference_data_db_${{ secrets.VERSION }}
+        path: reference_data_${{ secrets.VERSION }}.db

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
     jwt (2.5.0)
     memoist (0.16.2)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.5)
     minitest (5.16.2)
     multi_json (1.15.0)
     nio4r (2.5.8)
@@ -157,6 +158,8 @@ GEM
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
+    sqlite3 (1.6.3)
+      mini_portile2 (~> 2.8.0)
     timers (4.3.3)
     traces (0.4.1)
     trailblazer-option (0.1.2)
@@ -179,6 +182,7 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (~> 1.25)
   rubocop-rspec (~> 2.8)
+  sqlite3 (~> 1.4)
 
 BUNDLED WITH
    2.3.10

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require 'rspec/core/rake_task'
 
 require_relative 'lib/dfe/reference_data'
 require_relative 'lib/dfe/reference_data/bigquery/importer'
+require_relative 'lib/dfe/reference_data/bigquery/converter'
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -89,4 +90,11 @@ task :update_bigquery_tables do
   end
 
   DfE::ReferenceData::BigQuery.update_tables
+end
+
+desc 'Convert reference data to SQLite'
+task :convert_to_sqlite do
+  version = DfE::ReferenceData::VERSION
+  output_file = File.join(__dir__, "reference_data_#{version}.db")
+  DfE::ReferenceData::BigQuery::Converter.convert_to_sqlite(output_file, BIGQUERY_TABLES)
 end

--- a/dfe-reference-data.gemspec
+++ b/dfe-reference-data.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('rubocop', '~> 1.25')
   s.add_development_dependency('rubocop-rspec', '~> 2.8')
+  s.add_development_dependency('sqlite3', '~> 1.4')
 
   s.add_dependency 'activesupport'
   s.add_dependency 'tzinfo'

--- a/lib/dfe/reference_data/bigquery/converter.rb
+++ b/lib/dfe/reference_data/bigquery/converter.rb
@@ -1,0 +1,117 @@
+module DfE
+  module ReferenceData
+    module BigQuery
+      class Converter
+        def self.convert_to_sqlite(output_file, tables)
+          versioned_output_file = append_version_to_filename(output_file, DfE::ReferenceData::VERSION)
+
+          db = SQLite3::Database.new(versioned_output_file)
+
+          tables.each do |(table_name, list)|
+            create_table_and_insert_records(db, table_name, list)
+          end
+
+          db.close
+          puts "Data successfully converted to #{output_file}"
+        end
+
+        def self.append_version_to_filename(output_file, version)
+          extname = File.extname(output_file)
+          basename = File.basename(output_file, extname)
+          dirname = File.dirname(output_file)
+          "#{dirname}/#{basename}_#{version}#{extname}"
+        end
+
+        def self.create_table_and_insert_records(db, table_name, list)
+          create_table_sql = generate_create_table_sql(table_name, list.schema)
+          db.execute(create_table_sql)
+
+          db.transaction do
+            insert_records(db, table_name, list.all)
+          end
+        end
+
+        def self.insert_records(db, table_name, records)
+          records.each do |record|
+            insert_record(db, table_name, record)
+          end
+        end
+
+        def self.insert_record(db, table_name, record)
+          columns = record.keys.map(&:to_s)
+          placeholders = (['?'] * columns.size).join(',')
+          insert_sql = "INSERT INTO #{table_name} (#{columns.join(',')}) VALUES (#{placeholders})"
+          values = columns.map { |col| convert_value_for_sqlite(record[col.to_sym]) }
+          db.execute(insert_sql, values)
+        end
+
+        def self.generate_create_table_sql(table_name, schema)
+          columns = schema.map do |field_name, field_schema|
+            field_type = field_schema.is_a?(Hash) ? field_schema[:kind] : field_schema
+            "#{field_name} #{convert_to_sqlite_type(field_type)}"
+          end
+          "CREATE TABLE IF NOT EXISTS #{table_name} (#{columns.join(', ')})"
+        end
+
+        def self.convert_value_for_sqlite(value)
+          case value
+          when Array
+            convert_array_for_sqlite(value)
+          when Range
+            convert_range_for_sqlite(value)
+          when TrueClass, FalseClass
+            convert_boolean_for_sqlite(value)
+          else
+            convert_basic_type_for_sqlite(value)
+          end
+        end
+
+        def self.convert_basic_type_for_sqlite(value)
+          case value
+          when DateTime, Time
+            convert_datetime_for_sqlite(value)
+          when Hash
+            convert_hash_for_sqlite(value)
+          when NilClass
+            nil
+          else
+            value.to_s
+          end
+        end
+
+        def self.convert_to_sqlite_type(field_type)
+          case field_type
+          when 'boolean'
+            'INTEGER'
+          else
+            'TEXT'
+          end
+        end
+
+        def self.convert_array_for_sqlite(value)
+          if value.all? { |v| [true, false].include?(v) }
+            value.map { |v| v ? '1' : '0' }.join(',')
+          else
+            value.join(',')
+          end
+        end
+
+        def self.convert_range_for_sqlite(value)
+          "#{value.begin},#{value.end}"
+        end
+
+        def self.convert_boolean_for_sqlite(value)
+          value ? '1' : '0'
+        end
+
+        def self.convert_datetime_for_sqlite(value)
+          value.strftime('%Y-%m-%d %H:%M:%S')
+        end
+
+        def self.convert_hash_for_sqlite(value)
+          value.map { |k, v| "#{k}=#{v}" }.join(',')
+        end
+      end
+    end
+  end
+end

--- a/lib/dfe/reference_data/bigquery/converter.rb
+++ b/lib/dfe/reference_data/bigquery/converter.rb
@@ -1,115 +1,89 @@
+require_relative '../helpers/sqlite_conversion_helper'
+
 module DfE
   module ReferenceData
     module BigQuery
       class Converter
-        def self.convert_to_sqlite(output_file, tables)
-          versioned_output_file = append_version_to_filename(output_file, DfE::ReferenceData::VERSION)
+        extend DfE::ReferenceData::Helpers::SQLiteConversionHelper
 
-          db = SQLite3::Database.new(versioned_output_file)
+        class << self
+          def convert_to_sqlite(output_file, tables)
+            versioned_output_file = append_version_to_filename(output_file, DfE::ReferenceData::VERSION)
 
-          tables.each do |(table_name, list)|
-            create_table_and_insert_records(db, table_name, list)
+            db = SQLite3::Database.new(versioned_output_file)
+
+            tables.each do |(table_name, list)|
+              create_table_and_insert_records(db, table_name, list)
+            end
+
+            db.close
+            puts "Data successfully converted to #{output_file}"
+          rescue SQLite3::Exception => e
+            raise StandardError, "SQLite3 error during conversion: #{e.message}"
+          ensure
+            db&.close
           end
 
-          db.close
-          puts "Data successfully converted to #{output_file}"
-        end
-
-        def self.append_version_to_filename(output_file, version)
-          extname = File.extname(output_file)
-          basename = File.basename(output_file, extname)
-          dirname = File.dirname(output_file)
-          "#{dirname}/#{basename}_#{version}#{extname}"
-        end
-
-        def self.create_table_and_insert_records(db, table_name, list)
-          create_table_sql = generate_create_table_sql(table_name, list.schema)
-          db.execute(create_table_sql)
-
-          db.transaction do
-            insert_records(db, table_name, list.all)
+          def append_version_to_filename(output_file, version)
+            extname = File.extname(output_file)
+            basename = File.basename(output_file, extname)
+            dirname = File.dirname(output_file)
+            "#{dirname}/#{basename}_#{version}#{extname}"
+          rescue StandardError => e
+            raise StandardError, "Error generating versioned filename: #{e.message}"
           end
-        end
 
-        def self.insert_records(db, table_name, records)
-          records.each do |record|
-            insert_record(db, table_name, record)
+          def create_table_and_insert_records(db, table_name, list)
+            create_table_sql = generate_create_table_sql(table_name, list.schema)
+            db.execute(create_table_sql)
+
+            db.transaction do
+              insert_records(db, table_name, list.all)
+            end
+
+            create_indexes(db, table_name, list.schema)
+          rescue StandardError => e
+            raise StandardError, "Error generating CREATE TABLE SQL for #{table_name}: #{e.message}"
           end
-        end
 
-        def self.insert_record(db, table_name, record)
-          columns = record.keys.map(&:to_s)
-          placeholders = (['?'] * columns.size).join(',')
-          insert_sql = "INSERT INTO #{table_name} (#{columns.join(',')}) VALUES (#{placeholders})"
-          values = columns.map { |col| convert_value_for_sqlite(record[col.to_sym]) }
-          db.execute(insert_sql, values)
-        end
-
-        def self.generate_create_table_sql(table_name, schema)
-          columns = schema.map do |field_name, field_schema|
-            field_type = field_schema.is_a?(Hash) ? field_schema[:kind] : field_schema
-            "#{field_name} #{convert_to_sqlite_type(field_type)}"
+          def insert_records(db, table_name, records)
+            records.each do |record|
+              insert_record(db, table_name, record)
+            end
+          rescue StandardError => e
+            raise StandardError, "Error inserting records into #{table_name}: #{e.message}"
           end
-          "CREATE TABLE IF NOT EXISTS #{table_name} (#{columns.join(', ')})"
-        end
 
-        def self.convert_value_for_sqlite(value)
-          case value
-          when Array
-            convert_array_for_sqlite(value)
-          when Range
-            convert_range_for_sqlite(value)
-          when TrueClass, FalseClass
-            convert_boolean_for_sqlite(value)
-          else
-            convert_basic_type_for_sqlite(value)
+          def insert_record(db, table_name, record)
+            columns = record.keys.map(&:to_s)
+            placeholders = (['?'] * columns.size).join(',')
+            insert_sql = "INSERT INTO #{table_name} (#{columns.join(',')}) VALUES (#{placeholders})"
+            values = columns.map { |col| convert_value_for_sqlite(record[col.to_sym]) }
+            db.execute(insert_sql, values)
+          rescue StandardError => e
+            raise StandardError, "Error converting value for SQLite in #{table_name}: #{e.message}"
           end
-        end
 
-        def self.convert_basic_type_for_sqlite(value)
-          case value
-          when DateTime, Time
-            convert_datetime_for_sqlite(value)
-          when Hash
-            convert_hash_for_sqlite(value)
-          when NilClass
-            nil
-          else
-            value.to_s
+          def generate_create_table_sql(table_name, schema)
+            columns = schema.map do |field_name, field_schema|
+              field_type = field_schema.is_a?(Hash) ? field_schema[:kind] : field_schema
+              "#{field_name} #{convert_to_sqlite_type(field_type)}"
+            end
+            "CREATE TABLE IF NOT EXISTS #{table_name} (#{columns.join(', ')})"
+          rescue StandardError => e
+            raise StandardError, "Error generating CREATE TABLE SQL for #{table_name}: #{e.message}"
           end
-        end
 
-        def self.convert_to_sqlite_type(field_type)
-          case field_type
-          when 'boolean'
-            'INTEGER'
-          else
-            'TEXT'
+          def create_indexes(db, table_name, schema)
+            index_columns = schema.select { |_field_name, field_schema| %i[string integer].include?(field_schema) }
+
+            index_columns.each_key do |column|
+              create_index_sql = "CREATE INDEX IF NOT EXISTS idx_#{table_name}_#{column} ON #{table_name}(#{column})"
+              db.execute(create_index_sql)
+            end
+          rescue StandardError => e
+            raise StandardError, "Error creating index for #{table_name}: #{e.message}"
           end
-        end
-
-        def self.convert_array_for_sqlite(value)
-          if value.all? { |v| [true, false].include?(v) }
-            value.map { |v| v ? '1' : '0' }.join(',')
-          else
-            value.join(',')
-          end
-        end
-
-        def self.convert_range_for_sqlite(value)
-          "#{value.begin},#{value.end}"
-        end
-
-        def self.convert_boolean_for_sqlite(value)
-          value ? '1' : '0'
-        end
-
-        def self.convert_datetime_for_sqlite(value)
-          value.strftime('%Y-%m-%d %H:%M:%S')
-        end
-
-        def self.convert_hash_for_sqlite(value)
-          value.map { |k, v| "#{k}=#{v}" }.join(',')
         end
       end
     end

--- a/lib/dfe/reference_data/helpers/sqlite_conversion_helper.rb
+++ b/lib/dfe/reference_data/helpers/sqlite_conversion_helper.rb
@@ -13,7 +13,7 @@ module DfE
           else
             convert_basic_type_for_sqlite(value)
           end
-        rescue => e
+        rescue StandardError => e
           raise StandardError, "Error converting value for SQLite: #{e.message}"
         end
 
@@ -80,4 +80,3 @@ module DfE
     end
   end
 end
-  

--- a/lib/dfe/reference_data/helpers/sqlite_conversion_helper.rb
+++ b/lib/dfe/reference_data/helpers/sqlite_conversion_helper.rb
@@ -1,0 +1,83 @@
+module DfE
+  module ReferenceData
+    module Helpers
+      module SQLiteConversionHelper
+        def convert_value_for_sqlite(value)
+          case value
+          when Array
+            convert_array_for_sqlite(value)
+          when Range
+            convert_range_for_sqlite(value)
+          when TrueClass, FalseClass
+            convert_boolean_for_sqlite(value)
+          else
+            convert_basic_type_for_sqlite(value)
+          end
+        rescue => e
+          raise StandardError, "Error converting value for SQLite: #{e.message}"
+        end
+
+        def convert_basic_type_for_sqlite(value)
+          case value
+          when DateTime, Time
+            convert_datetime_for_sqlite(value)
+          when Hash
+            convert_hash_for_sqlite(value)
+          when NilClass
+            nil
+          else
+            value.to_s
+          end
+        rescue StandardError => e
+          raise StandardError, "Error converting basic type for SQLite: #{e.message}"
+        end
+
+        def convert_to_sqlite_type(field_type)
+          case field_type.to_s.downcase  # Convert both symbols and strings to lowercase strings
+          when 'boolean', 'integer'
+            'INTEGER'
+          else
+            'TEXT'
+          end
+        rescue StandardError => e
+          raise StandardError, "Error converting field type to SQLite type: #{e.message}"
+        end
+
+        def convert_array_for_sqlite(value)
+          if value.all? { |v| [true, false].include?(v) }
+            value.map { |v| v ? '1' : '0' }.join(',')
+          else
+            value.join(',')
+          end
+        rescue StandardError => e
+          raise StandardError, "Error converting array for SQLite: #{e.message}"
+        end
+
+        def convert_range_for_sqlite(value)
+          "#{value.begin},#{value.end}"
+        rescue StandardError => e
+          raise StandardError, "Error converting range for SQLite: #{e.message}"
+        end
+
+        def convert_boolean_for_sqlite(value)
+          value ? '1' : '0'
+        rescue StandardError => e
+          raise StandardError, "Error converting boolean for SQLite: #{e.message}"
+        end
+
+        def convert_datetime_for_sqlite(value)
+          value.strftime('%Y-%m-%d %H:%M:%S')
+        rescue StandardError => e
+          raise StandardError, "Error converting datetime for SQLite: #{e.message}"
+        end
+
+        def convert_hash_for_sqlite(value)
+          value.map { |k, v| "#{k}=#{v}" }.join(',')
+        rescue StandardError => e
+          raise StandardError, "Error converting hash for SQLite: #{e.message}"
+        end
+      end
+    end
+  end
+end
+  

--- a/spec/lib/dfe/reference_data/bigquery/converter_spec.rb
+++ b/spec/lib/dfe/reference_data/bigquery/converter_spec.rb
@@ -1,0 +1,143 @@
+require_relative '../../../../../lib/dfe/reference_data/bigquery/converter'
+require 'sqlite3'
+require 'securerandom'
+
+RSpec.describe DfE::ReferenceData::BigQuery::Converter do
+  let(:test_data) do
+    DfE::ReferenceData::HardcodedReferenceList.new(
+      {
+        'optionals_present' => {
+          single_string: 'hello',
+          single_symbol: :world,
+          single_boolean: true,
+          single_integer: 123,
+          single_real: 123.456,
+          single_datetime: DateTime.new(2022, 4, 4, 18, 0, 0),
+          single_daterange: Date.new(2021, 1, 1)..Date.new(2021, 12, 31),
+
+          optional_string: 'optional hello',
+          optional_symbol: :optional_world,
+          optional_boolean: false,
+          optional_integer: 456,
+          optional_real: 456.789,
+
+          array_string: ['array', 'of', 'strings'],
+          array_symbol: %i[array of symbols],
+          array_boolean: [true, false],
+          array_integer: [1, 2, 3],
+          array_real: [1.0, 2.0, 3.0],
+
+          map: {
+            food: 'Cheese',
+            drink: 'Irn Bru'
+          }
+        },
+        'optionals_absent' => {
+          single_string: 'goodbye',
+          single_symbol: :everybody,
+          single_boolean: false,
+          single_integer: -1,
+          single_real: -123.456,
+          single_datetime: DateTime.new(2022, 4, 4, 18, 0, 0),
+          single_daterange: Date.new(2021, 1, 1)..Date.new(2021, 12, 31)
+        }
+      },
+      schema: {
+        id: :string,
+        single_string: :string,
+        single_symbol: :symbol,
+        single_boolean: :boolean,
+        single_integer: :integer,
+        single_real: :real,
+        single_datetime: :datetime,
+        single_daterange: :daterange,
+
+        optional_string: { kind: :optional, schema: :string },
+        optional_symbol: { kind: :optional, schema: :symbol },
+        optional_boolean: { kind: :optional, schema: :boolean },
+        optional_integer: { kind: :optional, schema: :integer },
+        optional_real: { kind: :optional, schema: :real },
+
+        array_string: { kind: :array, element_schema: :string },
+        array_symbol: { kind: :array, element_schema: :symbol },
+        array_boolean: { kind: :array, element_schema: :boolean },
+        array_integer: { kind: :array, element_schema: :integer },
+        array_real: { kind: :array, element_schema: :real },
+
+        map: { kind: :map, key: :symbol, value: :string }
+      },
+      list_description: 'A list of dummy data',
+      list_docs_url: 'https://github.com/DFE-Digital/dfe-reference-data/blob/main/spec/lib/dfe/reference_data/bigquery/converter_spec.rb',
+      field_descriptions: {
+        id: 'An ID',
+        single_string: 'A single string',
+        optional_string: 'An optional string',
+        array_string: 'An array of strings',
+        map: 'A map',
+        nonexistant_field: 'A field that does not exist'
+      }
+    )
+  end
+
+  let(:output_file) { "test_#{SecureRandom.uuid}.db" }
+  let(:versioned_output_file) { output_file.sub('.db', "_#{DfE::ReferenceData::VERSION}.db") }
+
+  after(:each) do
+    File.delete(versioned_output_file) if File.exist?(versioned_output_file)
+  end
+
+  it 'creates an SQLite database and tables with versioned filename' do
+    DfE::ReferenceData::BigQuery::Converter.convert_to_sqlite(output_file, [['test_table', test_data]])
+
+    expect(File).to exist(versioned_output_file)
+
+    db = SQLite3::Database.new(versioned_output_file)
+    tables = db.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    expect(tables.flatten).to include('test_table')
+
+    columns = db.execute('PRAGMA table_info(test_table)')
+    expect(columns.map { |col| col[1] }).to include('id', 'single_string', 'optional_string', 'array_string', 'map')
+  end
+
+  it 'inserts the data correctly with versioned filename' do
+    DfE::ReferenceData::BigQuery::Converter.convert_to_sqlite(output_file, [['test_table', test_data]])
+
+    expect(File).to exist(versioned_output_file)
+
+    db = SQLite3::Database.new(versioned_output_file)
+    rows = db.execute('SELECT * FROM test_table')
+    expect(rows.size).to eq(2)
+
+    row_with_optionals = rows.find { |row| row[0] == 'optionals_present' }
+    expect(row_with_optionals[1..].map(&:to_s)).to include(
+      'hello',
+      'world',
+      '1', # SQLite3 stores booleans as 0/1 integers
+      '123',
+      '123.456',
+      '2022-04-04 18:00:00',
+      '2021-01-01,2021-12-31',
+      'optional hello',
+      'optional_world',
+      '0',
+      '456',
+      '456.789',
+      'array,of,strings',
+      'array,of,symbols',
+      '1,0', # Boolean array as '1,0'
+      '1,2,3',
+      '1.0,2.0,3.0',
+      'food=Cheese,drink=Irn Bru'
+    )
+  end
+
+  it 'does not fail with missing data' do
+    DfE::ReferenceData::BigQuery::Converter.convert_to_sqlite(output_file, [['test_table', test_data]])
+
+    expect(File).to exist(versioned_output_file)
+
+    db = SQLite3::Database.new(versioned_output_file)
+    rows = db.execute("SELECT * FROM test_table WHERE id = 'nonexistent'")
+    expect(rows).to be_empty
+  end
+end

--- a/spec/lib/dfe/reference_data/bigquery/converter_spec.rb
+++ b/spec/lib/dfe/reference_data/bigquery/converter_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe DfE::ReferenceData::BigQuery::Converter do
     expect(row_with_optionals[1..].map(&:to_s)).to include(
       'hello',
       'world',
-      '1', # SQLite3 stores booleans as 0/1 integers
+      '1', # SQLite3 boolean
       '123',
       '123.456',
       '2022-04-04 18:00:00',
@@ -124,7 +124,7 @@ RSpec.describe DfE::ReferenceData::BigQuery::Converter do
       '456.789',
       'array,of,strings',
       'array,of,symbols',
-      '1,0', # Boolean array as '1,0'
+      '1,0', # SQLite3 boolean array
       '1,2,3',
       '1.0,2.0,3.0',
       'food=Cheese,drink=Irn Bru'
@@ -139,5 +139,132 @@ RSpec.describe DfE::ReferenceData::BigQuery::Converter do
     db = SQLite3::Database.new(versioned_output_file)
     rows = db.execute("SELECT * FROM test_table WHERE id = 'nonexistent'")
     expect(rows).to be_empty
+  end
+
+  it 'does not fail with missing data' do
+    DfE::ReferenceData::BigQuery::Converter.convert_to_sqlite(output_file, [['test_table', test_data]])
+
+    expect(File).to exist(versioned_output_file)
+
+    db = SQLite3::Database.new(versioned_output_file)
+    rows = db.execute("SELECT * FROM test_table WHERE id = 'nonexistent'")
+    expect(rows).to be_empty
+  end
+
+  it 'handles different data edge cases' do
+    edge_cases_data = DfE::ReferenceData::HardcodedReferenceList.new(
+      {
+        'edge_cases' => {
+          single_string: '',
+          single_symbol: :edge,
+          single_boolean: true,
+          single_integer: (2**63) - 1, # Maximum 64-bit integer
+          single_real: -Float::INFINITY,
+          single_datetime: DateTime.new(9999, 12, 31, 23, 59, 59),
+          single_daterange: Date.new(1, 1, 1)..Date.new(9999, 12, 31),
+
+          optional_string: nil,
+          optional_symbol: nil,
+          optional_boolean: nil,
+          optional_integer: nil,
+          optional_real: nil,
+
+          array_string: [''],
+          array_symbol: %i[],
+          array_boolean: [],
+          array_integer: [0, -1, 1],
+          array_real: [0.0, Float::INFINITY, -Float::INFINITY],
+
+          map: { very_large_key: 'value', key: nil }
+        }
+      },
+      schema: {
+        id: :string,
+        single_string: :string,
+        single_symbol: :symbol,
+        single_boolean: :boolean,
+        single_integer: :integer,
+        single_real: :real,
+        single_datetime: :datetime,
+        single_daterange: :daterange,
+
+        optional_string: { kind: :optional, schema: :string },
+        optional_symbol: { kind: :optional, schema: :symbol },
+        optional_boolean: { kind: :optional, schema: :boolean },
+        optional_integer: { kind: :optional, schema: :integer },
+        optional_real: { kind: :optional, schema: :real },
+
+        array_string: { kind: :array, element_schema: :string },
+        array_symbol: { kind: :array, element_schema: :symbol },
+        array_boolean: { kind: :array, element_schema: :boolean },
+        array_integer: { kind: :array, element_schema: :integer },
+        array_real: { kind: :array, element_schema: :real },
+
+        map: { kind: :map, key: :symbol, value: :string }
+      }
+    )
+
+    DfE::ReferenceData::BigQuery::Converter.convert_to_sqlite(output_file, [['edge_cases', edge_cases_data]])
+
+    expect(File).to exist(versioned_output_file)
+
+    db = SQLite3::Database.new(versioned_output_file)
+    rows = db.execute('SELECT * FROM edge_cases')
+    expect(rows.size).to eq(1)
+
+    row = rows.first
+    expect(row).to include('', 'edge', 1, 9_223_372_036_854_775_807, '-Infinity', '9999-12-31 23:59:59', '0001-01-01,9999-12-31')
+    expect(row).to include('') # Empty string in array
+  end
+
+  it 'raises an error when there is an SQLite exception' do
+    allow(SQLite3::Database).to receive(:new).and_raise(SQLite3::SQLException.new('Test error'))
+
+    expect do
+      DfE::ReferenceData::BigQuery::Converter.convert_to_sqlite(output_file, [['test_table', test_data]])
+    end.to raise_error(StandardError, /SQLite3 error during conversion: Test error/)
+  end
+
+  it 'closes the database even if an exception is raised' do
+    db = instance_double('SQLite3::Database')
+    allow(SQLite3::Database).to receive(:new).and_return(db)
+    allow(db).to receive(:close)
+    allow(db).to receive(:execute).and_raise(SQLite3::SQLException.new('Test error'))
+
+    expect do
+      DfE::ReferenceData::BigQuery::Converter.convert_to_sqlite(output_file, [['test_table', test_data]])
+    end.to raise_error(StandardError)
+
+    expect(db).to have_received(:close)
+  end
+
+  it 'raises an error if generating the CREATE TABLE SQL fails' do
+    allow(DfE::ReferenceData::BigQuery::Converter).to receive(:generate_create_table_sql).and_raise(StandardError.new('generate_create_table_sql error'))
+
+    expect do
+      DfE::ReferenceData::BigQuery::Converter.convert_to_sqlite(output_file, [['test_table', test_data]])
+    end.to raise_error(StandardError, /Error generating CREATE TABLE SQL for test_table: generate_create_table_sql error/)
+  end
+
+  it 'raises an error when converting value for SQLite fails' do
+    allow(DfE::ReferenceData::BigQuery::Converter).to receive(:convert_value_for_sqlite).and_raise(StandardError.new('convert_value_for_sqlite error'))
+
+    expect do
+      DfE::ReferenceData::BigQuery::Converter.convert_to_sqlite(output_file, [['test_table', test_data]])
+    end.to raise_error(StandardError, /Error generating CREATE TABLE SQL for test_table: Error inserting records into test_table: Error converting value for SQLite in test_table: convert_value_for_sqlite error/)
+  end
+
+  it 'creates indexes on string and integer columns' do
+    DfE::ReferenceData::BigQuery::Converter.convert_to_sqlite(output_file, [['test_table', test_data]])
+
+    db = SQLite3::Database.new(versioned_output_file)
+    indexes = db.execute("SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='test_table'")
+
+    expected_indexes = ['idx_test_table_id', 'idx_test_table_single_string', 'idx_test_table_single_integer']
+    created_indexes = indexes.flatten
+
+    expected_indexes.each do |expected_index|
+      expect(created_indexes).to include(expected_index)
+    end
   end
 end


### PR DESCRIPTION
**Trello ticket:** [here](https://trello.com/c/usmgoJWN/2156-plt-6-dfereferencedata-add-script-to-allow-reference-data-to-be-converted-to-sqlite-db?filter=member:portererica) 

**Context:** 

Currently reference data gem is a static list of hashes, access to which is provided via Ruby or by generating static mappings in JSON format. Adding a script to the rakefile which converts the reference data to sqlite db will allow other non-RoRs (i.e. .net) applications to use it.

**This PR includes:**
1. A converter module which converts each table from dfe-reference-data to sqlite
2. A converter helper module which converts values / types to be compatible with sqlite
3. An update to the release.yml to make the versioned reference data db file accessible via Github
4. An update to the Rake file, adding a rake task to initiate the conversion of the tables listed in BIGQUERY_TABLES collection
5. Some tests to cover the new functionality N.B. comment out 
```
after(:each) do
    File.delete(versioned_output_file) if File.exist?(versioned_output_file)
end
``` 
to view the test sqlite files

**N.B. I have tested the sqlite file locally by running the rake task, inspecting the sqlite file checking all the tables existed, checking the scheme of the files and selecting data from the tables. I also tested that the file would be created as an artifact available on github by creating a test.yml which allowed me to view the file when I pushed a test branch. I was able to download the artifact file and interact with it** 
