### PR TITLE
Add 2025-2026 cycle dates

### DIFF
--- a/lib/dfe/reference_data/itt/cycles.rb
+++ b/lib/dfe/reference_data/itt/cycles.rb
@@ -72,7 +72,7 @@ module DfE
             apply_1_deadline: make_local_time(2022, 9, 6, 18), # 1st Tuesday of September
             apply_2_deadline: make_local_time(2022, 9, 20, 18), # 2 weeks after Apply 1 deadline
             provider_decision_deadline: make_local_time(2022, 9, 28, 23, 59, 59), # 1 week and a day after Apply 2 deadline
-            find_closes: make_local_time(2022, 10, 3, 23, 59, 59), # The evening before the find opens in the new cycle
+            find_closes: make_local_time(2022, 10, 3, 23, 59, 59), # The evening before find opens in the new cycle
             non_working_days: {
               christmas: Date.new(2021, 12, 14)..Date.new(2022, 1, 16),
               easter: Date.new(2022, 4, 4)..Date.new(2022, 4, 18)
@@ -84,7 +84,7 @@ module DfE
             apply_1_deadline: make_local_time(2023, 9, 5, 18), # 1st Tuesday of September
             apply_2_deadline: make_local_time(2023, 9, 19, 18), # 2 weeks after Apply 1 deadline
             provider_decision_deadline: make_local_time(2023, 9, 27, 23, 59, 59), # 1 week and a day after Apply 2 deadline
-            find_closes: make_local_time(2023, 10, 2, 23, 59, 59), # The evening before the find opens in the new cycle
+            find_closes: make_local_time(2023, 10, 2, 23, 59, 59), # The evening before find opens in the new cycle
             non_working_days: {
               christmas: Date.new(2022, 12, 19)..Date.new(2023, 1, 6),
               easter: Date.new(2023, 3, 27)..Date.new(2023, 4, 10)
@@ -96,7 +96,7 @@ module DfE
             apply_1_deadline: make_local_time(2024, 9, 3, 18), # 1st Tuesday of September
             apply_2_deadline: make_local_time(2024, 9, 17, 18), # 2 weeks after Apply 1 deadline
             provider_decision_deadline: make_local_time(2024, 9, 25, 23, 59, 59), # 1 week and a day after Apply 2 deadline
-            find_closes: make_local_time(2024, 9, 30, 23, 59, 59), # The evening before the find opens in the new cycle
+            find_closes: make_local_time(2024, 9, 30, 23, 59, 59), # The evening before find opens in the new cycle
             non_working_days: {
               christmas: Date.new(2023, 12, 18)..Date.new(2024, 1, 5),
               easter: Date.new(2024, 3, 18)..Date.new(2024, 4, 1)
@@ -106,9 +106,9 @@ module DfE
             find_opens: make_local_time(2024, 10, 1, 9), # First Tuesday of October
             apply_opens: make_local_time(2024, 10, 8, 9), # Second Tuesday of October
             apply_1_deadline: nil, # This deadline is not applicable for this cycle
-            apply_2_deadline: make_local_time(2025, 9, 16, 18), # 3rd Tuesday in September
+            apply_2_deadline: make_local_time(2025, 9, 16, 18), # 3rd Tuesday in September. This is the final and only deadline to send ITT applications in the cycle.
             provider_decision_deadline: make_local_time(2025, 9, 24, 23, 59, 59), # 1 week and a day after Apply 2 deadline
-            find_closes: make_local_time(2025, 10, 6, 23, 59, 59), # The evening before the find opens in the new cycle
+            find_closes: make_local_time(2025, 10, 6, 23, 59, 59), # The evening before find opens in the new cycle
             non_working_days: {
               christmas: Date.new(2024, 12, 16)..Date.new(2025, 1, 3),
               easter: Date.new(2025, 4, 7)..Date.new(2025, 4, 21)
@@ -118,9 +118,9 @@ module DfE
             find_opens: make_local_time(2025, 10, 7, 9), # First Tuesday of October
             apply_opens: make_local_time(2024, 10, 14, 9), # Second Tuesday of October
             apply_1_deadline: nil, # This deadline is not applicable for this cycle
-            apply_2_deadline: make_local_time(2026, 9, 22, 18), # 3rd Tuesday in September
+            apply_2_deadline: make_local_time(2026, 9, 22, 18), # 3rd Tuesday in September. This is the final and only deadline to send ITT applications in the cycle.
             provider_decision_deadline: make_local_time(2026, 9, 30, 23, 59, 59), # 1 week and a day after Apply 2 deadline
-            find_closes: make_local_time(2026, 10, 5, 23, 59, 59), # The evening before the find opens in the new cycle
+            find_closes: make_local_time(2026, 10, 5, 23, 59, 59), # The evening before find opens in the new cycle
             non_working_days: {
               christmas: Date.new(2025, 12, 22)..Date.new(2026, 1, 2),
               easter: Date.new(2026, 3, 30)..Date.new(2026, 4, 10)

--- a/lib/dfe/reference_data/itt/cycles.rb
+++ b/lib/dfe/reference_data/itt/cycles.rb
@@ -113,6 +113,18 @@ module DfE
               christmas: Date.new(2024, 12, 16)..Date.new(2025, 1, 3),
               easter: Date.new(2025, 4, 7)..Date.new(2025, 4, 21)
             }
+          },
+          '2025-2026' => {
+            find_opens: make_local_time(2025, 10, 7, 9), # First Tuesday of October
+            apply_opens: make_local_time(2024, 10, 14, 9), # Second Tuesday of October
+            apply_1_deadline: nil, # This deadline is not applicable for this cycle
+            apply_2_deadline: make_local_time(2026, 9, 22, 18), # 3rd Tuesday in September
+            provider_decision_deadline: make_local_time(2026, 9, 30, 23, 59, 59), # 1 week and a day after Apply 2 deadline
+            find_closes: make_local_time(2026, 10, 5, 23, 59, 59), # The evening before the find opens in the new cycle
+            non_working_days: {
+              christmas: Date.new(2025, 12, 22)..Date.new(2026, 1, 2),
+              easter: Date.new(2026, 3, 30)..Date.new(2026, 4, 10)
+            }
           }
         },
         schema: CYCLES_SCHEMA,

--- a/lib/dfe/reference_data/itt/cycles.rb
+++ b/lib/dfe/reference_data/itt/cycles.rb
@@ -106,7 +106,7 @@ module DfE
             find_opens: make_local_time(2024, 10, 1, 9), # First Tuesday of October
             apply_opens: make_local_time(2024, 10, 8, 9), # Second Tuesday of October
             apply_1_deadline: nil, # This deadline is not applicable for this cycle
-            apply_2_deadline: make_local_time(2025, 9, 16, 18), # 3rd Tuesday in September. This is the final and only deadline to send ITT applications in the cycle.
+            apply_2_deadline: make_local_time(2025, 9, 16, 18), # 3rd Tuesday in September. This is the final and only deadline to send ITT applications in the cycle
             provider_decision_deadline: make_local_time(2025, 9, 24, 23, 59, 59), # 1 week and a day after Apply 2 deadline
             find_closes: make_local_time(2025, 10, 6, 23, 59, 59), # The evening before find opens in the new cycle
             non_working_days: {
@@ -118,7 +118,7 @@ module DfE
             find_opens: make_local_time(2025, 10, 7, 9), # First Tuesday of October
             apply_opens: make_local_time(2024, 10, 14, 9), # Second Tuesday of October
             apply_1_deadline: nil, # This deadline is not applicable for this cycle
-            apply_2_deadline: make_local_time(2026, 9, 22, 18), # 3rd Tuesday in September. This is the final and only deadline to send ITT applications in the cycle.
+            apply_2_deadline: make_local_time(2026, 9, 22, 18), # 3rd Tuesday in September. This is the final and only deadline to send ITT applications in the cycle
             provider_decision_deadline: make_local_time(2026, 9, 30, 23, 59, 59), # 1 week and a day after Apply 2 deadline
             find_closes: make_local_time(2026, 10, 5, 23, 59, 59), # The evening before find opens in the new cycle
             non_working_days: {


### PR DESCRIPTION
Need to update the [dfe reference table](https://console.cloud.google.com/bigquery?project=rugged-abacus-218110&ws=!1m5!1m4!4m3!1srugged-abacus-218110!2sdfe_reference_data!3sitt_cycles_latest) for the future cycle and in this case include 2025-2026.

We need the start date of this to define the end date of the previous cycle in our reports - otherwise our reports won't update. Need to update dfe_reference_data.itt_cycles_latest