### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,5 +25,5 @@ jobs:
     - name: Upload SQLite Database
       uses: actions/upload-artifact@v4
       with:
-        name: reference_data_db_${{ secrets.VERSION }}
-        path: reference_data_${{ secrets.VERSION }}.db
+        name: reference_data_db_${{ github.ref_name }}
+        path: reference_data_${{ github.ref_name }}.db


### PR DESCRIPTION
SQLite artifact not available because secrets.version not working as expected -> 
Update release.yml with github.ref instead of secrets.version