### PR TITLE
Update 2025-26 cycle dates

### DIFF
--- a/lib/dfe/reference_data/itt/cycles.rb
+++ b/lib/dfe/reference_data/itt/cycles.rb
@@ -108,19 +108,20 @@ module DfE
             apply_1_deadline: nil, # This deadline is not applicable for this cycle
             apply_2_deadline: make_local_time(2025, 9, 16, 18), # 3rd Tuesday in September. This is the final and only deadline to send ITT applications in the cycle
             provider_decision_deadline: make_local_time(2025, 9, 24, 23, 59, 59), # 1 week and a day after Apply 2 deadline
-            find_closes: make_local_time(2025, 10, 6, 23, 59, 59), # The evening before find opens in the new cycle
+            find_closes: make_local_time(2025, 9, 30, 23, 59, 59), # The evening before find opens in the new cycle
             non_working_days: {
               christmas: Date.new(2024, 12, 16)..Date.new(2025, 1, 3),
               easter: Date.new(2025, 4, 7)..Date.new(2025, 4, 21)
             }
           },
           '2025-2026' => {
-            find_opens: make_local_time(2025, 10, 7, 9), # First Tuesday of October
-            apply_opens: make_local_time(2025, 10, 14, 9), # Second Tuesday of October
+            # For published dates, see: https://www.gov.uk/government/publications/recruiting-postgraduate-trainee-teachers-recruitment-cycle-dates/recruiting-postgraduate-trainee-teachers-recruitment-cycle-dates
+            find_opens: make_local_time(2025, 10, 1, 9), # Wednesday, first weekday in October
+            apply_opens: make_local_time(2025, 10, 8, 9), # Second Wednesday of October, one week after find opens
             apply_1_deadline: nil, # This deadline is not applicable for this cycle
-            apply_2_deadline: make_local_time(2026, 9, 22, 18), # 3rd Tuesday in September. This is the final and only deadline to send ITT applications in the cycle
-            provider_decision_deadline: make_local_time(2026, 9, 30, 23, 59, 59), # 1 week and a day after Apply 2 deadline
-            find_closes: make_local_time(2026, 10, 5, 23, 59, 59), # The evening before find opens in the new cycle
+            apply_2_deadline: make_local_time(2026, 9, 16, 18), # 3rd Wednesday in September. This is the final and only deadline to send ITT applications in the cycle
+            provider_decision_deadline: make_local_time(2026, 9, 24, 23, 59, 59), # 1 week and a day after Apply 2 deadline
+            find_closes: make_local_time(2026, 9, 30, 23, 59, 59), # The evening before find opens in the new cycle, estimated as of 15 October 2024
             non_working_days: {
               christmas: Date.new(2025, 12, 22)..Date.new(2026, 1, 2),
               easter: Date.new(2026, 3, 30)..Date.new(2026, 4, 10)


### PR DESCRIPTION
The dates in the current release do not reflect the dates approved for 2025-26. 

This PR updates the dates to match those in the [Apply/Manage codebase](https://github.com/DFE-Digital/apply-for-teacher-training/blob/e74388f964520c0d36f44911e207e59fdf2e171a/config/initializers/cycle_timetables.rb). 