### PR TITLE
Add degree grade value for HESA code '09'

### DIFF
--- a/lib/dfe/reference_data/degrees/grades.rb
+++ b/lib/dfe/reference_data/degrees/grades.rb
@@ -74,6 +74,13 @@ module DfE
             suggestion_synonyms: [],
             match_synonyms: [],
             group: :other },
+          'd2ffefd5-43f7-4c9e-aae5-341df5d880d0' =>
+          { hesa_code: '09',
+            name: 'Pass - degree awarded without honours following an honours course',
+            short_name: 'Pass without honours',
+            suggestion_synonyms: [],
+            match_synonyms: [],
+            group: :other },
           '4d3cc9d3-81dd-4457-ae2b-ee0bd298c51e' =>
           { hesa_code: '10',
             name: 'Ordinary degree',


### PR DESCRIPTION
## Add _Pass without honours_ degree grade value

The degree grade _Pass - degree awarded without honours following an honours course_ (HESA code '09') was not supported. This has been flagged as an issue by providers and vendors testing the new Register Trainee Teachers API. Therefore we are proposing that this value be added to DfE reference data.

See [HESA reference](https://www.hesa.ac.uk/collection/c24053/e/degclss)