### PR TITLE
v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v3.7.0](https://github.com/DFE-Digital/dfe-reference-data/tree/v3.7.0) (2025-04-09)
+
+[Full Changelog](https://github.com/DFE-Digital/dfe-reference-data/compare/v3.6.9...v3.7.0)
+
+**Implemented enhancements:**
+
+- V3.7.0 [\#141](https://github.com/DFE-Digital/dfe-reference-data/pull/141) ([Reyko](https://github.com/Reyko))
+
 ## [v3.6.9](https://github.com/DFE-Digital/dfe-reference-data/tree/v3.6.9) (2025-02-28)
 
 [Full Changelog](https://github.com/DFE-Digital/dfe-reference-data/compare/v3.6.8...v3.6.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,20 @@
 
 ## [v3.7.0](https://github.com/DFE-Digital/dfe-reference-data/tree/v3.7.0) (2025-04-09)
 
-[Full Changelog](https://github.com/DFE-Digital/dfe-reference-data/compare/v3.6.9...v3.7.0)
+[Full Changelog](https://github.com/DFE-Digital/dfe-reference-data/compare/v3.6.10...v3.7.0)
+
+**Merged pull requests:**
+
+- Add missing degree type mapping for 4 specific degrees [\#141](https://github.com/DFE-Digital/dfe-reference-data/pull/141) ([Reyko](https://github.com/Reyko))
+- Add degree grade value for HESA code '09' [\#140](https://github.com/DFE-Digital/dfe-reference-data/pull/140) ([stevehook](https://github.com/stevehook))
+
+## [v3.6.10](https://github.com/DFE-Digital/dfe-reference-data/tree/v3.6.10) (2025-03-03)
+
+[Full Changelog](https://github.com/DFE-Digital/dfe-reference-data/compare/v3.6.9...v3.6.10)
 
 **Implemented enhancements:**
 
-- V3.7.0 [\#141](https://github.com/DFE-Digital/dfe-reference-data/pull/141) ([Reyko](https://github.com/Reyko))
+- V3.6.10 [\#136](https://github.com/DFE-Digital/dfe-reference-data/pull/136) ([goodviber](https://github.com/goodviber))
 
 ## [v3.6.9](https://github.com/DFE-Digital/dfe-reference-data/tree/v3.6.9) (2025-02-28)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dfe-reference-data (3.6.10)
+    dfe-reference-data (3.7.0)
       activesupport
       tzinfo
 

--- a/lib/dfe/reference_data/version.rb
+++ b/lib/dfe/reference_data/version.rb
@@ -1,5 +1,5 @@
 module DfE
   module ReferenceData
-    VERSION = '3.6.10'.freeze
+    VERSION = '3.7.0'.freeze
   end
 end


### PR DESCRIPTION
Add support for new Register degree types

[8371-add-missing-degree-type-mapping-for-4-specific-degrees](https://trello.com/c/1MBUPAiU/8371-add-missing-degree-type-mapping-for-4-specific-degrees)

and [Add degree grade value for HESA code '09'](https://github.com/DFE-Digital/dfe-reference-data/pull/140)

Also updates changelog to include previously missing entry for `v3.6.10`.